### PR TITLE
feat: sign up, sign in, and sign out

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -43,6 +44,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.room.runtime)
+    ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,11 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".SignUpActivity" />
+        <activity android:name=".SignInActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/playground/MainActivity.kt
+++ b/app/src/main/java/com/example/playground/MainActivity.kt
@@ -1,12 +1,19 @@
 package com.example.playground
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.example.playground.auth.AuthManager
+import com.google.android.material.button.MaterialButton
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var authManager: AuthManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -15,6 +22,26 @@ class MainActivity : AppCompatActivity() {
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
+        }
+
+        authManager = AuthManager(this)
+
+        val currentUser = authManager.getCurrentUser()
+        if (currentUser == null) {
+            startActivity(Intent(this, SignInActivity::class.java))
+            finish()
+            return
+        }
+
+        val welcomeText = findViewById<TextView>(R.id.welcomeText)
+        val signOutButton = findViewById<MaterialButton>(R.id.signOutButton)
+
+        welcomeText.text = getString(R.string.welcome_message, currentUser.username)
+
+        signOutButton.setOnClickListener {
+            authManager.signOut()
+            startActivity(Intent(this, SignInActivity::class.java))
+            finish()
         }
     }
 }

--- a/app/src/main/java/com/example/playground/SignInActivity.kt
+++ b/app/src/main/java/com/example/playground/SignInActivity.kt
@@ -1,0 +1,63 @@
+package com.example.playground
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.example.playground.auth.AuthManager
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputLayout
+
+class SignInActivity : AppCompatActivity() {
+
+    private lateinit var authManager: AuthManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_sign_in)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        authManager = AuthManager(this)
+
+        val usernameLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
+        val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
+        val signInButton = findViewById<MaterialButton>(R.id.signInButton)
+        val signUpLink = findViewById<MaterialButton>(R.id.signUpLink)
+
+        signInButton.setOnClickListener {
+            usernameLayout.error = null
+            passwordLayout.error = null
+
+            val username = usernameLayout.editText?.text.toString().trim()
+            val password = passwordLayout.editText?.text.toString()
+
+            when (val result = authManager.signIn(username, password)) {
+                is AuthManager.AuthResult.Success -> {
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }
+                is AuthManager.AuthResult.Error -> {
+                    when {
+                        result.message.contains("Username is required") ->
+                            usernameLayout.error = result.message
+                        result.message.contains("Password is required") ->
+                            passwordLayout.error = result.message
+                        else -> passwordLayout.error = result.message
+                    }
+                }
+            }
+        }
+
+        signUpLink.setOnClickListener {
+            startActivity(Intent(this, SignUpActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/SignUpActivity.kt
+++ b/app/src/main/java/com/example/playground/SignUpActivity.kt
@@ -1,0 +1,63 @@
+package com.example.playground
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.example.playground.auth.AuthManager
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputLayout
+
+class SignUpActivity : AppCompatActivity() {
+
+    private lateinit var authManager: AuthManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_sign_up)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        authManager = AuthManager(this)
+
+        val usernameLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
+        val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
+        val signUpButton = findViewById<MaterialButton>(R.id.signUpButton)
+        val signInLink = findViewById<MaterialButton>(R.id.signInLink)
+
+        signUpButton.setOnClickListener {
+            usernameLayout.error = null
+            passwordLayout.error = null
+
+            val username = usernameLayout.editText?.text.toString().trim()
+            val password = passwordLayout.editText?.text.toString()
+
+            when (val result = authManager.signUp(username, password)) {
+                is AuthManager.AuthResult.Success -> {
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }
+                is AuthManager.AuthResult.Error -> {
+                    when {
+                        result.message.contains("Username is required") ->
+                            usernameLayout.error = result.message
+                        result.message.contains("Password is required") ->
+                            passwordLayout.error = result.message
+                        else -> usernameLayout.error = result.message
+                    }
+                }
+            }
+        }
+
+        signInLink.setOnClickListener {
+            startActivity(Intent(this, SignInActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/auth/AuthManager.kt
+++ b/app/src/main/java/com/example/playground/auth/AuthManager.kt
@@ -2,6 +2,7 @@ package com.example.playground.auth
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.database.sqlite.SQLiteConstraintException
 import com.example.playground.data.AppDatabase
 import com.example.playground.data.User
 import java.security.MessageDigest
@@ -29,7 +30,11 @@ class AuthManager(context: Context) {
         val salt = generateSalt()
         val hash = hashPassword(password, salt)
         val user = User(username = username, passwordHash = hash, salt = salt)
-        val id = userDao.insertUser(user)
+        val id = try {
+            userDao.insertUser(user)
+        } catch (_: SQLiteConstraintException) {
+            return AuthResult.Error("Username is already taken")
+        }
         val savedUser = user.copy(id = id)
 
         prefs.edit().putLong(KEY_USER_ID, id).apply()

--- a/app/src/main/java/com/example/playground/auth/AuthManager.kt
+++ b/app/src/main/java/com/example/playground/auth/AuthManager.kt
@@ -1,0 +1,80 @@
+package com.example.playground.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.example.playground.data.AppDatabase
+import com.example.playground.data.User
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+class AuthManager(context: Context) {
+
+    private val db = AppDatabase.getInstance(context)
+    private val userDao = db.userDao()
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+
+    sealed class AuthResult {
+        data class Success(val user: User) : AuthResult()
+        data class Error(val message: String) : AuthResult()
+    }
+
+    fun signUp(username: String, password: String): AuthResult {
+        if (username.isBlank()) return AuthResult.Error("Username is required")
+        if (password.isEmpty()) return AuthResult.Error("Password is required")
+        if (userDao.findByUsername(username) != null) {
+            return AuthResult.Error("Username is already taken")
+        }
+
+        val salt = generateSalt()
+        val hash = hashPassword(password, salt)
+        val user = User(username = username, passwordHash = hash, salt = salt)
+        val id = userDao.insertUser(user)
+        val savedUser = user.copy(id = id)
+
+        prefs.edit().putLong(KEY_USER_ID, id).apply()
+        return AuthResult.Success(savedUser)
+    }
+
+    fun signIn(username: String, password: String): AuthResult {
+        if (username.isBlank()) return AuthResult.Error("Username is required")
+        if (password.isEmpty()) return AuthResult.Error("Password is required")
+
+        val user = userDao.findByUsername(username)
+            ?: return AuthResult.Error("Invalid username or password")
+
+        val hash = hashPassword(password, user.salt)
+        if (hash != user.passwordHash) {
+            return AuthResult.Error("Invalid username or password")
+        }
+
+        prefs.edit().putLong(KEY_USER_ID, user.id).apply()
+        return AuthResult.Success(user)
+    }
+
+    fun signOut() {
+        prefs.edit().remove(KEY_USER_ID).apply()
+    }
+
+    fun getCurrentUser(): User? {
+        val userId = prefs.getLong(KEY_USER_ID, -1L)
+        if (userId == -1L) return null
+        return userDao.findById(userId)
+    }
+
+    companion object {
+        private const val KEY_USER_ID = "signed_in_user_id"
+
+        fun generateSalt(): String {
+            val bytes = ByteArray(16)
+            SecureRandom().nextBytes(bytes)
+            return bytes.joinToString("") { "%02x".format(it) }
+        }
+
+        fun hashPassword(password: String, salt: String): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            val bytes = digest.digest("$salt$password".toByteArray())
+            return bytes.joinToString("") { "%02x".format(it) }
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/playground/data/AppDatabase.kt
@@ -1,0 +1,26 @@
+package com.example.playground.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [User::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun userDao(): UserDao
+
+    companion object {
+        @Volatile
+        private var instance: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "playground.db"
+                ).allowMainThreadQueries().build().also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/data/User.kt
+++ b/app/src/main/java/com/example/playground/data/User.kt
@@ -1,0 +1,16 @@
+package com.example.playground.data
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "users",
+    indices = [Index(value = ["username"], unique = true)]
+)
+data class User(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val username: String,
+    val passwordHash: String,
+    val salt: String
+)

--- a/app/src/main/java/com/example/playground/data/UserDao.kt
+++ b/app/src/main/java/com/example/playground/data/UserDao.kt
@@ -1,0 +1,17 @@
+package com.example.playground.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface UserDao {
+    @Insert
+    fun insertUser(user: User): Long
+
+    @Query("SELECT * FROM users WHERE username = :username LIMIT 1")
+    fun findByUsername(username: String): User?
+
+    @Query("SELECT * FROM users WHERE id = :id LIMIT 1")
+    fun findById(id: Long): User?
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,6 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="24dp"
     tools:context=".MainActivity">
 
     <TextView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,15 +5,31 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="24dp"
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/welcomeText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintBottom_toTopOf="@id/signOutButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Welcome, player!" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signOutButton"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/action_sign_out"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/welcomeText" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sign_in_title"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintBottom_toTopOf="@id/usernameLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/usernameLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        app:layout_constraintBottom_toTopOf="@id/passwordLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/titleText">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/usernameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_username"
+            android:inputType="text"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/passwordLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintBottom_toTopOf="@id/signInButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/usernameLayout">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/passwordInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_password"
+            android:inputType="textPassword"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signInButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/action_sign_in"
+        app:layout_constraintBottom_toTopOf="@id/signUpLink"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/passwordLayout" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signUpLink"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/link_sign_up"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/signInButton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="24dp">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/titleText"
@@ -22,6 +21,7 @@
         android:id="@+id/usernameLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="32dp"
         app:layout_constraintBottom_toTopOf="@id/passwordLayout"
         app:layout_constraintEnd_toEndOf="parent"
@@ -41,6 +41,7 @@
         android:id="@+id/passwordLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="16dp"
         app:passwordToggleEnabled="true"
         app:layout_constraintBottom_toTopOf="@id/signInButton"
@@ -61,6 +62,7 @@
         android:id="@+id/signInButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="24dp"
         android:text="@string/action_sign_in"
         app:layout_constraintBottom_toTopOf="@id/signUpLink"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="24dp">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/titleText"
@@ -22,6 +21,7 @@
         android:id="@+id/usernameLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="32dp"
         app:layout_constraintBottom_toTopOf="@id/passwordLayout"
         app:layout_constraintEnd_toEndOf="parent"
@@ -41,6 +41,7 @@
         android:id="@+id/passwordLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="16dp"
         app:passwordToggleEnabled="true"
         app:layout_constraintBottom_toTopOf="@id/signUpButton"
@@ -61,6 +62,7 @@
         android:id="@+id/signUpButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="24dp"
         android:text="@string/action_sign_up"
         app:layout_constraintBottom_toTopOf="@id/signInLink"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sign_up_title"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintBottom_toTopOf="@id/usernameLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/usernameLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        app:layout_constraintBottom_toTopOf="@id/passwordLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/titleText">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/usernameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_username"
+            android:inputType="text"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/passwordLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintBottom_toTopOf="@id/signUpButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/usernameLayout">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/passwordInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_password"
+            android:inputType="textPassword"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signUpButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/action_sign_up"
+        app:layout_constraintBottom_toTopOf="@id/signInLink"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/passwordLayout" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signInLink"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/link_sign_in"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/signUpButton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
     <string name="app_name">PlayGround</string>
+    <string name="sign_up_title">Create Account</string>
+    <string name="sign_in_title">Welcome Back</string>
+    <string name="hint_username">Username</string>
+    <string name="hint_password">Password</string>
+    <string name="action_sign_up">Sign Up</string>
+    <string name="action_sign_in">Sign In</string>
+    <string name="action_sign_out">Sign Out</string>
+    <string name="link_sign_in">Already have an account? Sign In</string>
+    <string name="link_sign_up">Don\'t have an account? Sign Up</string>
+    <string name="welcome_message">Welcome, %1$s!</string>
 </resources>

--- a/app/src/test/java/com/example/playground/auth/AuthManagerTest.kt
+++ b/app/src/test/java/com/example/playground/auth/AuthManagerTest.kt
@@ -1,0 +1,40 @@
+package com.example.playground.auth
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class AuthManagerTest {
+
+    @Test
+    fun hashPassword_returnsDifferentHashForDifferentSalts() {
+        val hash1 = AuthManager.hashPassword("password", "salt1")
+        val hash2 = AuthManager.hashPassword("password", "salt2")
+        assertNotEquals(hash1, hash2)
+    }
+
+    @Test
+    fun hashPassword_returnsSameHashForSameInput() {
+        val hash1 = AuthManager.hashPassword("password", "salt1")
+        val hash2 = AuthManager.hashPassword("password", "salt1")
+        assertEquals(hash1, hash2)
+    }
+
+    @Test
+    fun hashPassword_returnsHexString() {
+        val hash = AuthManager.hashPassword("test", "salt")
+        assertTrue(hash.matches(Regex("^[0-9a-f]{64}$")))
+    }
+
+    @Test
+    fun generateSalt_returnsNonEmptyString() {
+        val salt = AuthManager.generateSalt()
+        assertTrue(salt.isNotEmpty())
+    }
+
+    @Test
+    fun generateSalt_returnsDifferentValues() {
+        val salt1 = AuthManager.generateSalt()
+        val salt2 = AuthManager.generateSalt()
+        assertNotEquals(salt1, salt2)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ appcompat = "1.7.1"
 material = "1.13.0"
 activity = "1.12.2"
 constraintlayout = "2.2.1"
+room = "2.8.4"
+ksp = "2.0.21-1.0.28"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,8 +21,10 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary

Adds local-only authentication to the PlayGround Android app, enabling users to register, sign in, and sign out. Multiple accounts are supported per device with persistent sessions across app restarts.

Closes #15

## What changed

- **Room database** with a `users` table storing username and salted SHA-256 password hashes
- **AuthManager** encapsulating all auth logic: sign up (with duplicate username protection), sign in with credential validation, sign out, and session persistence via SharedPreferences
- **SignUpActivity** and **SignInActivity** with Material 3 forms, inline field validation, and password visibility toggle
- **MainActivity** now checks for an active session on launch — redirects to sign-in if unauthenticated, shows the signed-in username with a sign-out button otherwise

## Design decisions

- `allowMainThreadQueries()` on Room for simplicity — the dataset is tiny and local-only. Can be migrated to coroutines when needed.
- Single `AuthManager` class called directly from Activities (no ViewModel) — keeps things simple for the current scope.
- `SQLiteConstraintException` is caught during sign-up as a safety net for the TOCTOU gap between the uniqueness check and insert.
- System bar insets are applied via `setPadding` for edge-to-edge support; form component padding is handled separately via `layout_marginHorizontal`.
