### PR TITLE
Convert authentication to use Firebase Auth

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.google.services)
 }
 
 android {
@@ -55,6 +56,10 @@ dependencies {
     implementation("com.google.android.gms:play-services-location:21.3.0")
     implementation("com.google.android.gms:play-services-maps:19.2.0")
     ksp(libs.androidx.room.compiler)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.auth.ktx)
+    implementation(libs.kotlinx.coroutines.play.services)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "853547212309",
+    "project_id": "playground-da88b",
+    "storage_bucket": "playground-da88b.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:853547212309:android:6b045cdea089b7eb46781c",
+        "android_client_info": {
+          "package_name": "com.example.playground"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAAe7B3aGJZ22PRpnJ39DYdoJmvSxiohDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/example/playground/SignInActivity.kt
+++ b/app/src/main/java/com/example/playground/SignInActivity.kt
@@ -6,9 +6,11 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
 import com.example.playground.auth.AuthManager
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.launch
 
 class SignInActivity : AppCompatActivity() {
 
@@ -26,30 +28,34 @@ class SignInActivity : AppCompatActivity() {
 
         authManager = AuthManager(this)
 
-        val usernameLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
+        val emailLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
         val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
         val signInButton = findViewById<MaterialButton>(R.id.signInButton)
         val signUpLink = findViewById<MaterialButton>(R.id.signUpLink)
 
         signInButton.setOnClickListener {
-            usernameLayout.error = null
+            emailLayout.error = null
             passwordLayout.error = null
 
-            val username = usernameLayout.editText?.text.toString().trim()
+            val email = emailLayout.editText?.text.toString().trim()
             val password = passwordLayout.editText?.text.toString()
 
-            when (val result = authManager.signIn(username, password)) {
-                is AuthManager.AuthResult.Success -> {
-                    startActivity(Intent(this, MainActivity::class.java))
-                    finish()
-                }
-                is AuthManager.AuthResult.Error -> {
-                    when {
-                        result.message.contains("Username is required") ->
-                            usernameLayout.error = result.message
-                        result.message.contains("Password is required") ->
-                            passwordLayout.error = result.message
-                        else -> passwordLayout.error = result.message
+            signInButton.isEnabled = false
+            lifecycleScope.launch {
+                when (val result = authManager.signIn(email, password)) {
+                    is AuthManager.AuthResult.Success -> {
+                        startActivity(Intent(this@SignInActivity, MainActivity::class.java))
+                        finish()
+                    }
+                    is AuthManager.AuthResult.Error -> {
+                        signInButton.isEnabled = true
+                        when {
+                            result.message.contains("Email", ignoreCase = true) ->
+                                emailLayout.error = result.message
+                            result.message.contains("Password", ignoreCase = true) ->
+                                passwordLayout.error = result.message
+                            else -> passwordLayout.error = result.message
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/playground/SignUpActivity.kt
+++ b/app/src/main/java/com/example/playground/SignUpActivity.kt
@@ -6,9 +6,11 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
 import com.example.playground.auth.AuthManager
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.launch
 
 class SignUpActivity : AppCompatActivity() {
 
@@ -26,30 +28,34 @@ class SignUpActivity : AppCompatActivity() {
 
         authManager = AuthManager(this)
 
-        val usernameLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
+        val emailLayout = findViewById<TextInputLayout>(R.id.usernameLayout)
         val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
         val signUpButton = findViewById<MaterialButton>(R.id.signUpButton)
         val signInLink = findViewById<MaterialButton>(R.id.signInLink)
 
         signUpButton.setOnClickListener {
-            usernameLayout.error = null
+            emailLayout.error = null
             passwordLayout.error = null
 
-            val username = usernameLayout.editText?.text.toString().trim()
+            val email = emailLayout.editText?.text.toString().trim()
             val password = passwordLayout.editText?.text.toString()
 
-            when (val result = authManager.signUp(username, password)) {
-                is AuthManager.AuthResult.Success -> {
-                    startActivity(Intent(this, MainActivity::class.java))
-                    finish()
-                }
-                is AuthManager.AuthResult.Error -> {
-                    when {
-                        result.message.contains("Username is required") ->
-                            usernameLayout.error = result.message
-                        result.message.contains("Password is required") ->
-                            passwordLayout.error = result.message
-                        else -> usernameLayout.error = result.message
+            signUpButton.isEnabled = false
+            lifecycleScope.launch {
+                when (val result = authManager.signUp(email, password)) {
+                    is AuthManager.AuthResult.Success -> {
+                        startActivity(Intent(this@SignUpActivity, MainActivity::class.java))
+                        finish()
+                    }
+                    is AuthManager.AuthResult.Error -> {
+                        signUpButton.isEnabled = true
+                        when {
+                            result.message.contains("Email", ignoreCase = true) ->
+                                emailLayout.error = result.message
+                            result.message.contains("Password", ignoreCase = true) ->
+                                passwordLayout.error = result.message
+                            else -> emailLayout.error = result.message
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/playground/auth/AuthManager.kt
+++ b/app/src/main/java/com/example/playground/auth/AuthManager.kt
@@ -2,16 +2,17 @@ package com.example.playground.auth
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.database.sqlite.SQLiteConstraintException
 import com.example.playground.data.AppDatabase
 import com.example.playground.data.User
-import java.security.MessageDigest
-import java.security.SecureRandom
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.tasks.await
 
 class AuthManager(context: Context) {
 
     private val db = AppDatabase.getInstance(context)
     private val userDao = db.userDao()
+    private val firebaseAuth = FirebaseAuth.getInstance()
     private val prefs: SharedPreferences =
         context.getSharedPreferences("auth", Context.MODE_PRIVATE)
 
@@ -20,66 +21,65 @@ class AuthManager(context: Context) {
         data class Error(val message: String) : AuthResult()
     }
 
-    fun signUp(username: String, password: String): AuthResult {
-        if (username.isBlank()) return AuthResult.Error("Username is required")
+    suspend fun signUp(email: String, password: String): AuthResult {
+        if (email.isBlank()) return AuthResult.Error("Email is required")
         if (password.isEmpty()) return AuthResult.Error("Password is required")
-        if (userDao.findByUsername(username) != null) {
-            return AuthResult.Error("Username is already taken")
-        }
 
-        val salt = generateSalt()
-        val hash = hashPassword(password, salt)
-        val user = User(username = username, passwordHash = hash, salt = salt)
-        val id = try {
-            userDao.insertUser(user)
-        } catch (_: SQLiteConstraintException) {
-            return AuthResult.Error("Username is already taken")
-        }
-        val savedUser = user.copy(id = id)
+        return try {
+            val result = firebaseAuth.createUserWithEmailAndPassword(email, password).await()
+            val firebaseUser = result.user
+                ?: return AuthResult.Error("Sign up failed")
 
-        prefs.edit().putLong(KEY_USER_ID, id).apply()
-        return AuthResult.Success(savedUser)
+            val user = saveLocalUser(firebaseUser)
+            prefs.edit().putString(KEY_FIREBASE_UID, firebaseUser.uid).apply()
+            firebaseAuth.signOut()
+            AuthResult.Success(user)
+        } catch (e: Exception) {
+            AuthResult.Error(e.message ?: "Sign up failed")
+        }
     }
 
-    fun signIn(username: String, password: String): AuthResult {
-        if (username.isBlank()) return AuthResult.Error("Username is required")
+    suspend fun signIn(email: String, password: String): AuthResult {
+        if (email.isBlank()) return AuthResult.Error("Email is required")
         if (password.isEmpty()) return AuthResult.Error("Password is required")
 
-        val user = userDao.findByUsername(username)
-            ?: return AuthResult.Error("Invalid username or password")
+        return try {
+            val result = firebaseAuth.signInWithEmailAndPassword(email, password).await()
+            val firebaseUser = result.user
+                ?: return AuthResult.Error("Sign in failed")
 
-        val hash = hashPassword(password, user.salt)
-        if (hash != user.passwordHash) {
-            return AuthResult.Error("Invalid username or password")
+            val user = saveLocalUser(firebaseUser)
+            prefs.edit().putString(KEY_FIREBASE_UID, firebaseUser.uid).apply()
+            firebaseAuth.signOut()
+            AuthResult.Success(user)
+        } catch (e: Exception) {
+            AuthResult.Error(e.message ?: "Sign in failed")
         }
-
-        prefs.edit().putLong(KEY_USER_ID, user.id).apply()
-        return AuthResult.Success(user)
     }
 
     fun signOut() {
-        prefs.edit().remove(KEY_USER_ID).apply()
+        prefs.edit().remove(KEY_FIREBASE_UID).apply()
     }
 
     fun getCurrentUser(): User? {
-        val userId = prefs.getLong(KEY_USER_ID, -1L)
-        if (userId == -1L) return null
-        return userDao.findById(userId)
+        val uid = prefs.getString(KEY_FIREBASE_UID, null) ?: return null
+        return userDao.findByFirebaseUid(uid)
+    }
+
+    private fun saveLocalUser(firebaseUser: FirebaseUser): User {
+        val existing = userDao.findByFirebaseUid(firebaseUser.uid)
+        if (existing != null) return existing
+
+        val user = User(
+            firebaseUid = firebaseUser.uid,
+            email = firebaseUser.email ?: "",
+            displayName = firebaseUser.displayName ?: ""
+        )
+        val id = userDao.insertUser(user)
+        return user.copy(id = id)
     }
 
     companion object {
-        private const val KEY_USER_ID = "signed_in_user_id"
-
-        fun generateSalt(): String {
-            val bytes = ByteArray(16)
-            SecureRandom().nextBytes(bytes)
-            return bytes.joinToString("") { "%02x".format(it) }
-        }
-
-        fun hashPassword(password: String, salt: String): String {
-            val digest = MessageDigest.getInstance("SHA-256")
-            val bytes = digest.digest("$salt$password".toByteArray())
-            return bytes.joinToString("") { "%02x".format(it) }
-        }
+        private const val KEY_FIREBASE_UID = "signed_in_firebase_uid"
     }
 }

--- a/app/src/main/java/com/example/playground/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/playground/data/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [User::class, Event::class, Comment::class], version = 5)
+@Database(entities = [User::class, Event::class, Comment::class], version = 6)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun eventDao(): EventDao

--- a/app/src/main/java/com/example/playground/data/User.kt
+++ b/app/src/main/java/com/example/playground/data/User.kt
@@ -6,11 +6,11 @@ import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "users",
-    indices = [Index(value = ["username"], unique = true)]
+    indices = [Index(value = ["firebaseUid"], unique = true)]
 )
 data class User(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val username: String,
-    val passwordHash: String,
-    val salt: String
+    val firebaseUid: String,
+    val email: String,
+    val displayName: String = ""
 )

--- a/app/src/main/java/com/example/playground/data/UserDao.kt
+++ b/app/src/main/java/com/example/playground/data/UserDao.kt
@@ -2,15 +2,16 @@ package com.example.playground.data
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
 @Dao
 interface UserDao {
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertUser(user: User): Long
 
-    @Query("SELECT * FROM users WHERE username = :username LIMIT 1")
-    fun findByUsername(username: String): User?
+    @Query("SELECT * FROM users WHERE firebaseUid = :uid LIMIT 1")
+    fun findByFirebaseUid(uid: String): User?
 
     @Query("SELECT * FROM users WHERE id = :id LIMIT 1")
     fun findById(id: Long): User?

--- a/app/src/main/java/com/example/playground/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/playground/repository/AuthRepository.kt
@@ -1,75 +1,16 @@
 package com.example.playground.repository
 
 import android.content.Context
-import android.content.SharedPreferences
-import android.database.sqlite.SQLiteConstraintException
-import com.example.playground.data.AppDatabase
+import com.example.playground.auth.AuthManager
 import com.example.playground.data.User
-import java.security.MessageDigest
-import java.security.SecureRandom
 
 class AuthRepository(context: Context) {
 
-    private val db = AppDatabase.getInstance(context)
-    private val userDao = db.userDao()
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+    private val authManager = AuthManager(context)
 
-    sealed class AuthResult {
-        data class Success(val user: User) : AuthResult()
-        data class Error(val message: String) : AuthResult()
-    }
-
-    fun signUp(username: String, password: String): AuthResult {
-        if (username.isBlank()) return AuthResult.Error("Username is required")
-        if (password.isEmpty()) return AuthResult.Error("Password is required")
-        if (userDao.findByUsername(username) != null) {
-            return AuthResult.Error("Username is already taken")
-        }
-
-        val salt = generateSalt()
-        val hash = hashPassword(password, salt)
-        val user = User(username = username, passwordHash = hash, salt = salt)
-        val id = try {
-            userDao.insertUser(user)
-        } catch (_: SQLiteConstraintException) {
-            return AuthResult.Error("Username is already taken")
-        }
-        val savedUser = user.copy(id = id)
-
-        prefs.edit().putLong(KEY_USER_ID, id).apply()
-        return AuthResult.Success(savedUser)
-    }
-
-    fun signIn(username: String, password: String): AuthResult {
-        if (username.isBlank()) return AuthResult.Error("Username is required")
-        if (password.isEmpty()) return AuthResult.Error("Password is required")
-
-        val user = userDao.findByUsername(username)
-            ?: return AuthResult.Error("Invalid username or password")
-
-        val hash = hashPassword(password, user.salt)
-        if (hash != user.passwordHash) {
-            return AuthResult.Error("Invalid username or password")
-        }
-
-        prefs.edit().putLong(KEY_USER_ID, user.id).apply()
-        return AuthResult.Success(user)
-    }
-
-    fun signOut() {
-        prefs.edit().remove(KEY_USER_ID).apply()
-    }
-
-    fun getCurrentUser(): User? {
-        val userId = prefs.getLong(KEY_USER_ID, -1L)
-        if (userId == -1L) return null
-        return userDao.findById(userId)
-    }
+    fun getCurrentUser(): User? = authManager.getCurrentUser()
 
     companion object {
-        private const val KEY_USER_ID = "signed_in_user_id"
-
         @Volatile
         private var instance: AuthRepository? = null
 
@@ -77,18 +18,6 @@ class AuthRepository(context: Context) {
             return instance ?: synchronized(this) {
                 instance ?: AuthRepository(context).also { instance = it }
             }
-        }
-
-        fun generateSalt(): String {
-            val bytes = ByteArray(16)
-            SecureRandom().nextBytes(bytes)
-            return bytes.joinToString("") { "%02x".format(it) }
-        }
-
-        fun hashPassword(password: String, salt: String): String {
-            val digest = MessageDigest.getInstance("SHA-256")
-            val bytes = digest.digest("$salt$password".toByteArray())
-            return bytes.joinToString("") { "%02x".format(it) }
         }
     }
 }

--- a/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
@@ -348,7 +348,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     private fun getHostDisplayName(event: Event): String {
         val currentUser = authManager.getCurrentUser()
         return if (currentUser != null && currentUser.id == event.hostId) {
-            currentUser.username
+            currentUser.displayName.ifEmpty { currentUser.email }
         } else {
             "Host #${event.hostId}"
         }
@@ -521,7 +521,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         for (comment in comments) {
             val authorName = if (currentUser != null && currentUser.id == comment.authorId) {
-                currentUser.username
+                currentUser.displayName.ifEmpty { currentUser.email }
             } else {
                 "User ${comment.authorId}"
             }

--- a/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
@@ -1,5 +1,6 @@
 package com.example.playground.ui.profile
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.example.playground.R
+import com.example.playground.SignInActivity
 import com.example.playground.auth.AuthManager
 import com.example.playground.data.AppDatabase
 import com.google.android.material.button.MaterialButton
@@ -29,7 +31,7 @@ class ProfileFragment : Fragment() {
         authManager = AuthManager(requireContext())
         val db = AppDatabase.getInstance(requireContext())
         val userDao = db.userDao()
-        
+
         var user = authManager.getCurrentUser()
 
         val nameInput = view.findViewById<TextInputEditText>(R.id.nameInput)
@@ -38,17 +40,16 @@ class ProfileFragment : Fragment() {
         val editProfileButton = view.findViewById<MaterialButton>(R.id.editProfileButton)
         val logoutButton = view.findViewById<MaterialButton>(R.id.logoutButton)
 
-        nameInput.setText(user?.username ?: "Guest")
-        emailInput.setText((if (user != null) user.username else "guest") + "@example.com")
+        nameInput.setText(user?.displayName?.ifEmpty { user?.email } ?: "Guest")
+        emailInput.setText(user?.email ?: "")
         savedCourtsInput.setText("0 saved courts")
         nameInput.isEnabled = false
 
         editProfileButton.setOnClickListener {
             if (isEditing) {
-                // Save logic
                 val newName = nameInput.text.toString().trim()
                 if (newName.isNotEmpty() && user != null) {
-                    user = user!!.copy(username = newName)
+                    user = user!!.copy(displayName = newName)
                     userDao.updateUser(user!!)
                     nameInput.isEnabled = false
                     editProfileButton.text = "Edit Profile"
@@ -56,7 +57,6 @@ class ProfileFragment : Fragment() {
                     Toast.makeText(requireContext(), "Profile updated", Toast.LENGTH_SHORT).show()
                 }
             } else {
-                // Enter edit mode
                 nameInput.isEnabled = true
                 nameInput.requestFocus()
                 editProfileButton.text = "Save Profile"
@@ -67,7 +67,7 @@ class ProfileFragment : Fragment() {
         logoutButton.setOnClickListener {
             authManager.signOut()
             requireActivity().finish()
-            startActivity(android.content.Intent(requireContext(), com.example.playground.SignInActivity::class.java))
+            startActivity(Intent(requireContext(), SignInActivity::class.java))
         }
     }
 }

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -32,8 +32,8 @@
             android:id="@+id/usernameInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_username"
-            android:inputType="text"
+            android:hint="@string/hint_email"
+            android:inputType="textEmailAddress"
             android:maxLines="1" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -32,8 +32,8 @@
             android:id="@+id/usernameInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_username"
-            android:inputType="text"
+            android:hint="@string/hint_email"
+            android:inputType="textEmailAddress"
             android:maxLines="1" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="sign_up_title">Create Account</string>
     <string name="sign_in_title">Welcome Back</string>
     <string name="hint_username">Username</string>
+    <string name="hint_email">Email</string>
     <string name="hint_password">Password</string>
     <string name="action_sign_up">Sign Up</string>
     <string name="action_sign_in">Sign In</string>

--- a/app/src/test/java/com/example/playground/auth/AuthManagerTest.kt
+++ b/app/src/test/java/com/example/playground/auth/AuthManagerTest.kt
@@ -6,35 +6,20 @@ import org.junit.Test
 class AuthManagerTest {
 
     @Test
-    fun hashPassword_returnsDifferentHashForDifferentSalts() {
-        val hash1 = AuthManager.hashPassword("password", "salt1")
-        val hash2 = AuthManager.hashPassword("password", "salt2")
-        assertNotEquals(hash1, hash2)
+    fun authResult_success_holdsUser() {
+        val user = com.example.playground.data.User(
+            id = 1L,
+            firebaseUid = "test-uid",
+            email = "test@example.com",
+            displayName = "Test User"
+        )
+        val result = AuthManager.AuthResult.Success(user)
+        assertEquals(user, result.user)
     }
 
     @Test
-    fun hashPassword_returnsSameHashForSameInput() {
-        val hash1 = AuthManager.hashPassword("password", "salt1")
-        val hash2 = AuthManager.hashPassword("password", "salt1")
-        assertEquals(hash1, hash2)
-    }
-
-    @Test
-    fun hashPassword_returnsHexString() {
-        val hash = AuthManager.hashPassword("test", "salt")
-        assertTrue(hash.matches(Regex("^[0-9a-f]{64}$")))
-    }
-
-    @Test
-    fun generateSalt_returnsNonEmptyString() {
-        val salt = AuthManager.generateSalt()
-        assertTrue(salt.isNotEmpty())
-    }
-
-    @Test
-    fun generateSalt_returnsDifferentValues() {
-        val salt1 = AuthManager.generateSalt()
-        val salt2 = AuthManager.generateSalt()
-        assertNotEquals(salt1, salt2)
+    fun authResult_error_holdsMessage() {
+        val result = AuthManager.AuthResult.Error("Something went wrong")
+        assertEquals("Something went wrong", result.message)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ constraintlayout = "2.2.1"
 room = "2.8.4"
 lifecycle = "2.8.7"
 ksp = "2.0.21-1.0.28"
+googleServices = "4.4.2"
+firebaseBom = "33.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,7 +32,13 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
+
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version = "1.8.1" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }


### PR DESCRIPTION
## Summary

- Replace custom local password-based auth with Firebase Authentication (email/password)
- Session is managed locally via SharedPreferences (storing Firebase UID) — Firebase's built-in session persistence is NOT used
- Update User entity schema: removed `passwordHash`/`salt`, added `firebaseUid`/`email`/`displayName`
- Sign-in/sign-up flows now use async coroutine-based Firebase calls
- AuthRepository simplified to a thin wrapper around AuthManager

## Setup Required

After merging, you need to:
1. Create a Firebase project at https://console.firebase.google.com
2. Add an Android app with package name `com.example.playground`
3. Download `google-services.json` and place it in the `app/` directory
4. Enable Email/Password auth provider in Firebase Console → Authentication → Sign-in method