### PR TITLE
Add Firebase Firestore as remote database sync layer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
     implementation(libs.kotlinx.coroutines.play.services)
 
     testImplementation(libs.junit)

--- a/app/src/main/java/com/example/playground/auth/AuthManager.kt
+++ b/app/src/main/java/com/example/playground/auth/AuthManager.kt
@@ -6,6 +6,7 @@ import com.example.playground.data.AppDatabase
 import com.example.playground.data.User
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 
 class AuthManager(context: Context) {
@@ -13,6 +14,8 @@ class AuthManager(context: Context) {
     private val db = AppDatabase.getInstance(context)
     private val userDao = db.userDao()
     private val firebaseAuth = FirebaseAuth.getInstance()
+    private val firestore = FirebaseFirestore.getInstance()
+    private val usersCollection = firestore.collection("users")
     private val prefs: SharedPreferences =
         context.getSharedPreferences("auth", Context.MODE_PRIVATE)
 
@@ -66,9 +69,17 @@ class AuthManager(context: Context) {
         return userDao.findByFirebaseUid(uid)
     }
 
-    private fun saveLocalUser(firebaseUser: FirebaseUser): User {
+    fun updateUser(user: User) {
+        userDao.updateUser(user)
+        syncUserToFirestore(user)
+    }
+
+    private suspend fun saveLocalUser(firebaseUser: FirebaseUser): User {
         val existing = userDao.findByFirebaseUid(firebaseUser.uid)
-        if (existing != null) return existing
+        if (existing != null) {
+            syncUserToFirestore(existing)
+            return existing
+        }
 
         val user = User(
             firebaseUid = firebaseUser.uid,
@@ -76,7 +87,13 @@ class AuthManager(context: Context) {
             displayName = firebaseUser.displayName ?: ""
         )
         val id = userDao.insertUser(user)
-        return user.copy(id = id)
+        val saved = user.copy(id = id)
+        syncUserToFirestore(saved)
+        return saved
+    }
+
+    private fun syncUserToFirestore(user: User) {
+        usersCollection.document(user.firebaseUid).set(user.toFirestoreMap())
     }
 
     companion object {

--- a/app/src/main/java/com/example/playground/data/Comment.kt
+++ b/app/src/main/java/com/example/playground/data/Comment.kt
@@ -29,4 +29,23 @@ data class Comment(
     val authorId: Long,
     val content: String,
     val timestamp: Long
-)
+) {
+    fun toFirestoreMap(
+        eventFirestoreId: String,
+        authorFirebaseUid: String
+    ): Map<String, Any> = mapOf(
+        "eventFirestoreId" to eventFirestoreId,
+        "authorFirebaseUid" to authorFirebaseUid,
+        "content" to content,
+        "timestamp" to timestamp
+    )
+
+    companion object {
+        fun fromFirestoreMap(data: Map<String, Any?>): Comment = Comment(
+            content = data["content"] as? String ?: "",
+            timestamp = (data["timestamp"] as? Long) ?: 0L,
+            eventId = 0,
+            authorId = 0
+        )
+    }
+}

--- a/app/src/main/java/com/example/playground/data/Event.kt
+++ b/app/src/main/java/com/example/playground/data/Event.kt
@@ -23,7 +23,7 @@ data class Event(
     val sport: String,
     val title: String,
     val description: String?,
-    val startTime: Long, // Timestamp
+    val startTime: Long,
     val maxPlayers: Int,
     val imageUri: String? = null,
     val latitude: Double,
@@ -31,4 +31,36 @@ data class Event(
     val locationLabel: String,
     val address: String? = null,
     val published: Boolean = true
-)
+) {
+    fun toFirestoreMap(hostFirebaseUid: String): Map<String, Any?> = mapOf(
+        "hostFirebaseUid" to hostFirebaseUid,
+        "sport" to sport,
+        "title" to title,
+        "description" to description,
+        "startTime" to startTime,
+        "maxPlayers" to maxPlayers,
+        "imageUri" to imageUri,
+        "latitude" to latitude,
+        "longitude" to longitude,
+        "locationLabel" to locationLabel,
+        "address" to address,
+        "published" to published
+    )
+
+    companion object {
+        fun fromFirestoreMap(data: Map<String, Any?>): Event = Event(
+            sport = data["sport"] as? String ?: "",
+            title = data["title"] as? String ?: "",
+            description = data["description"] as? String,
+            startTime = (data["startTime"] as? Long) ?: 0L,
+            maxPlayers = (data["maxPlayers"] as? Long)?.toInt() ?: 0,
+            imageUri = data["imageUri"] as? String,
+            latitude = (data["latitude"] as? Double) ?: 0.0,
+            longitude = (data["longitude"] as? Double) ?: 0.0,
+            locationLabel = data["locationLabel"] as? String ?: "",
+            address = data["address"] as? String,
+            published = (data["published"] as? Boolean) ?: true,
+            hostId = 0
+        )
+    }
+}

--- a/app/src/main/java/com/example/playground/data/User.kt
+++ b/app/src/main/java/com/example/playground/data/User.kt
@@ -13,4 +13,18 @@ data class User(
     val firebaseUid: String,
     val email: String,
     val displayName: String = ""
-)
+) {
+    fun toFirestoreMap(): Map<String, Any> = mapOf(
+        "firebaseUid" to firebaseUid,
+        "email" to email,
+        "displayName" to displayName
+    )
+
+    companion object {
+        fun fromFirestoreMap(data: Map<String, Any?>): User = User(
+            firebaseUid = data["firebaseUid"] as? String ?: "",
+            email = data["email"] as? String ?: "",
+            displayName = data["displayName"] as? String ?: ""
+        )
+    }
+}

--- a/app/src/main/java/com/example/playground/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/playground/repository/EventRepository.kt
@@ -2,12 +2,19 @@ package com.example.playground.repository
 
 import android.content.Context
 import com.example.playground.data.AppDatabase
+import com.example.playground.data.Comment
 import com.example.playground.data.Event
+import com.google.firebase.firestore.FirebaseFirestore
 
 class EventRepository(context: Context) {
     private val db = AppDatabase.getInstance(context)
     private val eventDao = db.eventDao()
     private val commentDao = db.commentDao()
+    private val userDao = db.userDao()
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val eventsCollection = firestore.collection("events")
+    private val commentsCollection = firestore.collection("comments")
 
     sealed class EventResult {
         data class Success(val eventId: Long) : EventResult()
@@ -22,6 +29,7 @@ class EventRepository(context: Context) {
         if (event.latitude == 0.0 && event.longitude == 0.0) return EventResult.Error("Valid location is required")
 
         val id = eventDao.insertEvent(event)
+        syncEventToFirestore(event.copy(id = id))
         return EventResult.Success(id)
     }
 
@@ -31,34 +39,50 @@ class EventRepository(context: Context) {
 
     fun updateEvent(hostId: Long, event: Event): EventResult {
         if (event.hostId != hostId) return EventResult.Error("Unauthorized")
-        
+
         if (event.sport.isBlank()) return EventResult.Error("Sport is required")
         if (event.title.isBlank()) return EventResult.Error("Title is required")
         if (event.maxPlayers < 1) return EventResult.Error("Max players must be at least 1")
-        
+
         eventDao.updateEvent(event)
+        syncEventToFirestore(event)
         return EventResult.Success(event.id)
     }
 
     fun deleteEvent(hostId: Long, event: Event): EventResult {
         if (event.hostId != hostId) return EventResult.Error("Unauthorized")
         eventDao.deleteEvent(event)
+        eventsCollection.document(event.id.toString()).delete()
         return EventResult.Success(event.id)
     }
 
     fun postComment(eventId: Long, authorId: Long, content: String): EventResult {
-        val comment = com.example.playground.data.Comment(
+        val comment = Comment(
             eventId = eventId,
             authorId = authorId,
             content = content,
             timestamp = System.currentTimeMillis()
         )
         val id = commentDao.insertComment(comment)
+        syncCommentToFirestore(comment.copy(id = id))
         return EventResult.Success(id)
     }
 
-    fun getCommentsForEvent(eventId: Long): List<com.example.playground.data.Comment> = 
+    fun getCommentsForEvent(eventId: Long): List<Comment> =
         commentDao.getCommentsByEvent(eventId)
+
+    private fun syncEventToFirestore(event: Event) {
+        val host = userDao.findById(event.hostId)
+        val hostUid = host?.firebaseUid ?: ""
+        eventsCollection.document(event.id.toString()).set(event.toFirestoreMap(hostUid))
+    }
+
+    private fun syncCommentToFirestore(comment: Comment) {
+        val author = userDao.findById(comment.authorId)
+        val authorUid = author?.firebaseUid ?: ""
+        commentsCollection.document(comment.id.toString())
+            .set(comment.toFirestoreMap(comment.eventId.toString(), authorUid))
+    }
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.Fragment
 import com.example.playground.R
 import com.example.playground.SignInActivity
 import com.example.playground.auth.AuthManager
-import com.example.playground.data.AppDatabase
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 
@@ -29,8 +28,6 @@ class ProfileFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         authManager = AuthManager(requireContext())
-        val db = AppDatabase.getInstance(requireContext())
-        val userDao = db.userDao()
 
         var user = authManager.getCurrentUser()
 
@@ -50,7 +47,7 @@ class ProfileFragment : Fragment() {
                 val newName = nameInput.text.toString().trim()
                 if (newName.isNotEmpty() && user != null) {
                     user = user!!.copy(displayName = newName)
-                    userDao.updateUser(user!!)
+                    authManager.updateUser(user!!)
                     nameInput.isEnabled = false
                     editProfileButton.text = "Edit Profile"
                     isEditing = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
 
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version = "1.8.1" }
 


### PR DESCRIPTION
## Summary
- Add Firebase Firestore as a **remote sync layer** while keeping Room as the local database (per project requirements)
- All writes (users, events, comments) are saved to both Room locally and Firestore remotely
- Reads continue from Room for offline-first performance
- Profile updates are synced to Firestore via `AuthManager.updateUser()`
