### PR TITLE
Enforce MVVM pattern with ViewModel + LiveData across all fragments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.livedata.ktx)
 
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.androidx.navigation.safeargs.kotlin)
 }
 
 android {
@@ -50,6 +51,9 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/app/src/main/java/com/example/playground/MainActivity.kt
+++ b/app/src/main/java/com/example/playground/MainActivity.kt
@@ -6,12 +6,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupWithNavController
 import com.example.playground.auth.AuthManager
-import com.example.playground.ui.home.CreateEventFragment
-import com.example.playground.ui.map.MapFragment
-import com.example.playground.ui.myposts.MyPostsFragment
-import com.example.playground.ui.profile.ProfileFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
@@ -38,27 +35,11 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
+        val navHostFragment = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navController = navHostFragment.navController
+
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_navigation)
-
-        bottomNav.setOnItemSelectedListener { item ->
-            when (item.itemId) {
-                R.id.nav_map -> replaceFragment(MapFragment())
-                R.id.nav_create -> replaceFragment(CreateEventFragment())
-                R.id.nav_my_posts -> replaceFragment(MyPostsFragment())
-                R.id.nav_profile -> replaceFragment(ProfileFragment())
-            }
-            true
-        }
-
-        if (savedInstanceState == null) {
-            replaceFragment(MapFragment())
-            bottomNav.selectedItemId = R.id.nav_map
-        }
-    }
-
-    private fun replaceFragment(fragment: Fragment) {
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.nav_host_fragment, fragment)
-            .commit()
+        bottomNav.setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/example/playground/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/playground/repository/AuthRepository.kt
@@ -10,6 +10,10 @@ class AuthRepository(context: Context) {
 
     fun getCurrentUser(): User? = authManager.getCurrentUser()
 
+    fun updateUser(user: User) = authManager.updateUser(user)
+
+    fun signOut() = authManager.signOut()
+
     companion object {
         @Volatile
         private var instance: AuthRepository? = null

--- a/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
@@ -16,13 +16,14 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.ViewModelProvider
 import com.example.playground.R
-import com.example.playground.auth.AuthManager
 import com.example.playground.data.Event
 import com.example.playground.data.Venue
 import com.example.playground.data.Venues
+import com.example.playground.repository.AuthRepository
 import com.example.playground.repository.EventRepository
+import com.example.playground.viewmodel.MapViewModel
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -33,12 +34,10 @@ import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.chip.Chip
 import com.google.android.material.textfield.TextInputEditText
-import kotlinx.coroutines.launch
 
 class MapFragment : Fragment(), OnMapReadyCallback {
 
-    private lateinit var authManager: AuthManager
-    private lateinit var eventRepository: EventRepository
+    private lateinit var viewModel: MapViewModel
 
     private var googleMap: GoogleMap? = null
     private var userLocation: LatLng? = null
@@ -85,9 +84,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
     private lateinit var eventImageView: android.widget.ImageView
 
-    private var allEvents: List<Event> = emptyList()
-    private var selectedSport: String = "All"
-    private var selectedEvent: Event? = null
     private var activeExpanded = true
 
     companion object {
@@ -106,11 +102,16 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        authManager = AuthManager(requireContext())
-        eventRepository = EventRepository.getInstance(requireContext())
+        val authRepository = AuthRepository.getInstance(requireContext())
+        val eventRepository = EventRepository.getInstance(requireContext())
+        viewModel = ViewModelProvider(
+            this,
+            MapViewModel.Factory(authRepository, eventRepository)
+        )[MapViewModel::class.java]
 
         bindViews(view)
         setupActions()
+        observeViewModel()
 
         val mapFragment = childFragmentManager.findFragmentById(R.id.map) as? SupportMapFragment
         mapFragment?.getMapAsync(this)
@@ -175,18 +176,22 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
 
         imComingButton.setOnClickListener {
-            joinSelectedEvent()
+            viewModel.joinOrUnjoinEvent()
         }
 
         addCommentButton.setOnClickListener {
-            addCommentToSelectedEvent()
+            val text = commentInput.text.toString().trim()
+            if (text.isNotBlank()) {
+                viewModel.postComment(text)
+                commentInput.setText("")
+            }
         }
 
-        star1.setOnClickListener { rateSelectedEvent(1) }
-        star2.setOnClickListener { rateSelectedEvent(2) }
-        star3.setOnClickListener { rateSelectedEvent(3) }
-        star4.setOnClickListener { rateSelectedEvent(4) }
-        star5.setOnClickListener { rateSelectedEvent(5) }
+        star1.setOnClickListener { viewModel.rateEvent(1) }
+        star2.setOnClickListener { viewModel.rateEvent(2) }
+        star3.setOnClickListener { viewModel.rateEvent(3) }
+        star4.setOnClickListener { viewModel.rateEvent(4) }
+        star5.setOnClickListener { viewModel.rateEvent(5) }
 
         chipAllSports.setOnClickListener { setSport("All") }
         chipBasketball.setOnClickListener { setSport("Basketball") }
@@ -196,7 +201,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         searchInput.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
-                applyFilters()
+                viewModel.setSearchQuery(searchInput.text?.toString().orEmpty())
                 true
             } else {
                 false
@@ -204,6 +209,21 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
 
         updateChipSelection()
+    }
+
+    private fun observeViewModel() {
+        viewModel.filteredEvents.observe(viewLifecycleOwner) { events ->
+            showMarkers(events)
+            activeGamesCountText.text = "${events.size} games near you"
+        }
+
+        viewModel.eventDetails.observe(viewLifecycleOwner) { details ->
+            if (details != null) renderDetails(details)
+        }
+
+        viewModel.comments.observe(viewLifecycleOwner) { comments ->
+            renderComments(comments)
+        }
     }
 
     override fun onMapReady(map: GoogleMap) {
@@ -216,7 +236,8 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         map.setOnMarkerClickListener { marker ->
             val event = marker.tag as? Event
             if (event != null) {
-                showDetails(event)
+                detailsCard.visibility = View.VISIBLE
+                viewModel.selectEvent(event)
                 map.animateCamera(
                     CameraUpdateFactory.newLatLngZoom(
                         LatLng(event.latitude, event.longitude),
@@ -231,43 +252,22 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             closeDetails()
         }
 
-        lifecycleScope.launch {
-            allEvents = eventRepository.getAllEvents()
-            applyFilters()
-        }
+        viewModel.loadEvents()
         enableMyLocation()
     }
 
     private fun setSport(sport: String) {
-        selectedSport = sport
+        viewModel.setSport(sport)
         updateChipSelection()
-        applyFilters()
     }
 
     private fun updateChipSelection() {
-        chipAllSports.isChecked = selectedSport == "All"
-        chipBasketball.isChecked = selectedSport == "Basketball"
-        chipFootball.isChecked = selectedSport == "Football"
-        chipTennis.isChecked = selectedSport == "Tennis"
-        chipVolleyball.isChecked = selectedSport == "Volleyball"
-    }
-
-    private fun applyFilters() {
-        val query = searchInput.text?.toString().orEmpty().trim().lowercase()
-
-        val filtered = allEvents.filter { event ->
-            val hasCoordinates = event.latitude != 0.0 && event.longitude != 0.0
-            val sportMatches = selectedSport == "All" || event.sport.equals(selectedSport, ignoreCase = true)
-            val textMatches = query.isEmpty() ||
-                    event.title.lowercase().contains(query) ||
-                    event.sport.lowercase().contains(query) ||
-                    event.locationLabel.lowercase().contains(query)
-
-            hasCoordinates && sportMatches && textMatches
-        }
-
-        showMarkers(filtered)
-        activeGamesCountText.text = "${filtered.size} games near you"
+        val sport = viewModel.selectedSport
+        chipAllSports.isChecked = sport == "All"
+        chipBasketball.isChecked = sport == "Basketball"
+        chipFootball.isChecked = sport == "Football"
+        chipTennis.isChecked = sport == "Tennis"
+        chipVolleyball.isChecked = sport == "Volleyball"
     }
 
     private fun showMarkers(events: List<Event>) {
@@ -286,34 +286,15 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
     }
 
-    private fun showDetails(event: Event) {
-        selectedEvent = event
-        detailsCard.visibility = View.VISIBLE
-        renderDetails(event)
-
-        lifecycleScope.launch {
-            eventRepository.fetchJoinsForEvent(event.id)
-            eventRepository.fetchRatingsForEvent(event.id)
-            refreshComments(event.id)
-            if (selectedEvent?.id == event.id) {
-                renderDetails(event)
-            }
-        }
-    }
-
-    private fun renderDetails(event: Event) {
-        val currentUser = authManager.getCurrentUser()
-        val participantCount = eventRepository.getJoinCount(event.id)
-        val isJoined = currentUser != null && eventRepository.isJoined(event.id, currentUser.id)
-        val userRating = currentUser?.let { eventRepository.getUserRating(event.id, it.id) }
-        val avgRating = eventRepository.getAverageRating(event.id)
-        val displayRating = userRating ?: avgRating.toInt().coerceAtLeast(1)
+    private fun renderDetails(details: MapViewModel.EventDetails) {
+        val event = details.event
+        val displayRating = details.userRating ?: details.averageRating.toInt().coerceAtLeast(1)
 
         hostAvatarText.text = getSportEmoji(event.sport)
-        hostNameText.text = getHostDisplayName(event)
+        hostNameText.text = details.hostDisplayName
         postedAgoText.text = formatTimeAgo(event.startTime)
         sportChipText.text = event.sport
-        joiningCountText.text = "$participantCount / ${event.maxPlayers} joining"
+        joiningCountText.text = "${details.participantCount} / ${event.maxPlayers} joining"
         titleText.text = event.title
         descriptionText.text = event.description ?: ""
         locationText.text = "📍 ${event.locationLabel}"
@@ -331,18 +312,16 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
 
         when {
-            isJoined -> {
+            details.isJoined -> {
                 imComingButton.text = "Cancel Join"
                 imComingButton.isEnabled = true
-
                 imComingButton.setBackgroundColor(0xFFE0E0E0.toInt())
                 imComingButton.setTextColor(0xFF444444.toInt())
             }
 
-            participantCount >= event.maxPlayers -> {
+            details.participantCount >= event.maxPlayers -> {
                 imComingButton.text = "Game Full"
                 imComingButton.isEnabled = false
-
                 imComingButton.setBackgroundColor(0xFFCCCCCC.toInt())
                 imComingButton.setTextColor(0xFF888888.toInt())
             }
@@ -350,7 +329,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             else -> {
                 imComingButton.text = "I'm Coming!"
                 imComingButton.isEnabled = true
-
                 imComingButton.setBackgroundColor(0xFF2A5BD7.toInt())
                 imComingButton.setTextColor(0xFFFFFFFF.toInt())
             }
@@ -359,69 +337,72 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         updateRatingViews(displayRating)
     }
 
-    private fun getHostDisplayName(event: Event): String {
-        val currentUser = authManager.getCurrentUser()
-        return if (currentUser != null && currentUser.id == event.hostId) {
-            currentUser.displayName.ifEmpty { currentUser.email }
-        } else {
-            "Host #${event.hostId}"
-        }
-    }
+    private fun renderComments(comments: List<MapViewModel.CommentWithAuthor>) {
+        commentsHeaderText.text = "Comments (${comments.size})"
+        commentListContainer.removeAllViews()
 
-    private fun joinSelectedEvent() {
-        val event = selectedEvent ?: return
-        val currentUser = authManager.getCurrentUser() ?: return
-
-        if (eventRepository.isJoined(event.id, currentUser.id)) {
-            eventRepository.unjoinEvent(event.id, currentUser.id)
-        } else {
-            val joinCount = eventRepository.getJoinCount(event.id)
-            if (joinCount >= event.maxPlayers) {
-                renderDetails(event)
-                return
+        for (item in comments) {
+            val row = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.HORIZONTAL
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    setMargins(0, 14, 0, 0)
+                }
             }
-            eventRepository.joinEvent(event.id, currentUser.id)
-        }
-        renderDetails(event)
-    }
 
-    private fun rateSelectedEvent(stars: Int) {
-        val event = selectedEvent ?: return
-        val currentUser = authManager.getCurrentUser() ?: return
-        val clamped = stars.coerceIn(1, 5)
-        eventRepository.rateEvent(event.id, currentUser.id, clamped)
-        renderDetails(event)
-    }
-
-    private fun updateRatingViews(rating: Int) {
-        val stars = listOf(star1, star2, star3, star4, star5)
-
-        stars.forEachIndexed { index, textView ->
-            val selected = index < rating
-            textView.text = if (selected) "★" else "☆"
-            textView.alpha = if (selected) 1f else 0.45f
-        }
-
-        ratingValueText.text = "%.1f".format(rating.toFloat())
-    }
-
-    private fun addCommentToSelectedEvent() {
-        val event = selectedEvent ?: return
-        val user = authManager.getCurrentUser() ?: return
-        val text = commentInput.text.toString().trim()
-
-        if (text.isNotBlank()) {
-            eventRepository.postComment(event.id, user.id, text)
-            commentInput.setText("")
-            lifecycleScope.launch {
-                refreshComments(event.id)
+            val avatar = TextView(requireContext()).apply {
+                text = "👤"
+                textSize = 22f
+                gravity = Gravity.CENTER
+                setBackgroundColor(0xFFE8F0FE.toInt())
+                layoutParams = LinearLayout.LayoutParams(44.dpToPx(), 44.dpToPx())
             }
+
+            val bubble = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.VERTICAL
+                setBackgroundColor(0xFFF5F5F5.toInt())
+                setPadding(14.dpToPx(), 12.dpToPx(), 14.dpToPx(), 12.dpToPx())
+                layoutParams = LinearLayout.LayoutParams(
+                    0,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    1f
+                ).apply {
+                    setMargins(12.dpToPx(), 0, 0, 0)
+                }
+            }
+
+            val authorView = TextView(requireContext()).apply {
+                text = item.authorName
+                textSize = 15f
+                setTextColor(0xFF444444.toInt())
+                setTypeface(null, Typeface.BOLD)
+            }
+
+            val bodyView = TextView(requireContext()).apply {
+                text = item.comment.content
+                textSize = 15f
+                setTextColor(0xFF555555.toInt())
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    setMargins(0, 5.dpToPx(), 0, 0)
+                }
+            }
+
+            bubble.addView(authorView)
+            bubble.addView(bodyView)
+            row.addView(avatar)
+            row.addView(bubble)
+            commentListContainer.addView(row)
         }
     }
 
     private fun closeDetails() {
         detailsCard.visibility = View.GONE
-        selectedEvent = null
+        viewModel.clearSelectedEvent()
     }
 
     @SuppressLint("MissingPermission")
@@ -516,76 +497,16 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }.sortedBy { it.second }
     }
 
-    private suspend fun refreshComments(eventId: Long) {
-        val comments = eventRepository.getCommentsForEvent(eventId)
-        val currentUser = authManager.getCurrentUser()
+    private fun updateRatingViews(rating: Int) {
+        val stars = listOf(star1, star2, star3, star4, star5)
 
-        commentsHeaderText.text = "Comments (${comments.size})"
-        commentListContainer.removeAllViews()
-
-        for (comment in comments) {
-            val authorName = if (currentUser != null && currentUser.id == comment.authorId) {
-                currentUser.displayName.ifEmpty { currentUser.email }
-            } else {
-                "User ${comment.authorId}"
-            }
-
-            val row = LinearLayout(requireContext()).apply {
-                orientation = LinearLayout.HORIZONTAL
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply {
-                    setMargins(0, 14, 0, 0)
-                }
-            }
-
-            val avatar = TextView(requireContext()).apply {
-                text = "👤"
-                textSize = 22f
-                gravity = Gravity.CENTER
-                setBackgroundColor(0xFFE8F0FE.toInt())
-                layoutParams = LinearLayout.LayoutParams(44.dpToPx(), 44.dpToPx())
-            }
-
-            val bubble = LinearLayout(requireContext()).apply {
-                orientation = LinearLayout.VERTICAL
-                setBackgroundColor(0xFFF5F5F5.toInt())
-                setPadding(14.dpToPx(), 12.dpToPx(), 14.dpToPx(), 12.dpToPx())
-                layoutParams = LinearLayout.LayoutParams(
-                    0,
-                    LinearLayout.LayoutParams.WRAP_CONTENT,
-                    1f
-                ).apply {
-                    setMargins(12.dpToPx(), 0, 0, 0)
-                }
-            }
-
-            val authorView = TextView(requireContext()).apply {
-                text = authorName
-                textSize = 15f
-                setTextColor(0xFF444444.toInt())
-                setTypeface(null, Typeface.BOLD)
-            }
-
-            val bodyView = TextView(requireContext()).apply {
-                text = comment.content
-                textSize = 15f
-                setTextColor(0xFF555555.toInt())
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply {
-                    setMargins(0, 5.dpToPx(), 0, 0)
-                }
-            }
-
-            bubble.addView(authorView)
-            bubble.addView(bodyView)
-            row.addView(avatar)
-            row.addView(bubble)
-            commentListContainer.addView(row)
+        stars.forEachIndexed { index, textView ->
+            val selected = index < rating
+            textView.text = if (selected) "★" else "☆"
+            textView.alpha = if (selected) 1f else 0.45f
         }
+
+        ratingValueText.text = "%.1f".format(rating.toFloat())
     }
 
     private fun getSportEmoji(sport: String): String {

--- a/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
@@ -7,27 +7,25 @@ import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.playground.R
-import com.example.playground.auth.AuthManager
 import com.example.playground.data.Event
+import com.example.playground.repository.AuthRepository
 import com.example.playground.repository.EventRepository
+import com.example.playground.viewmodel.MyPostsViewModel
 import com.google.android.material.button.MaterialButton
-import com.google.android.material.card.MaterialCardView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import android.app.AlertDialog
 import android.net.Uri
 import android.widget.ImageView
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.launch
 
 class MyPostsFragment : Fragment() {
 
-    private lateinit var authManager: AuthManager
-    private lateinit var eventRepository: EventRepository
+    private lateinit var viewModel: MyPostsViewModel
     private lateinit var recyclerView: RecyclerView
     private lateinit var emptyText: TextView
 
@@ -38,34 +36,48 @@ class MyPostsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        authManager = AuthManager(requireContext())
-        eventRepository = EventRepository.getInstance(requireContext())
+
+        val authRepository = AuthRepository.getInstance(requireContext())
+        val eventRepository = EventRepository.getInstance(requireContext())
+        viewModel = ViewModelProvider(
+            this,
+            MyPostsViewModel.Factory(authRepository, eventRepository)
+        )[MyPostsViewModel::class.java]
+
         recyclerView = view.findViewById(R.id.recyclerView)
         emptyText = view.findViewById(R.id.emptyText)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        loadEvents()
+
+        observeViewModel()
+        viewModel.loadEvents()
     }
 
-    private fun loadEvents() {
-        val user = authManager.getCurrentUser() ?: return
-        lifecycleScope.launch {
-            loadEventsAsync(user.id)
-        }
-    }
-
-    private suspend fun loadEventsAsync(userId: Long) {
-        val myEvents = eventRepository.getAllEvents().filter { it.hostId == userId }
-        if (myEvents.isEmpty()) {
-            recyclerView.visibility = View.GONE
-            emptyText.visibility = View.VISIBLE
-        } else {
-            recyclerView.visibility = View.VISIBLE
-            emptyText.visibility = View.GONE
+    private fun observeViewModel() {
+        viewModel.myEvents.observe(viewLifecycleOwner) { events ->
             recyclerView.adapter = MyEventsAdapter(
-                items = myEvents.toMutableList(),
+                items = events.toMutableList(),
                 onEdit = { event -> showEditDialog(event) },
                 onDelete = { event -> showDeleteDialog(event) }
             )
+        }
+
+        viewModel.isEmpty.observe(viewLifecycleOwner) { empty ->
+            recyclerView.visibility = if (empty) View.GONE else View.VISIBLE
+            emptyText.visibility = if (empty) View.VISIBLE else View.GONE
+        }
+
+        viewModel.operationResult.observe(viewLifecycleOwner) { result ->
+            when (result) {
+                is MyPostsViewModel.OperationResult.Success -> {
+                    Toast.makeText(context, result.message, Toast.LENGTH_SHORT).show()
+                    viewModel.clearOperationResult()
+                }
+                is MyPostsViewModel.OperationResult.Error -> {
+                    Toast.makeText(context, result.message, Toast.LENGTH_SHORT).show()
+                    viewModel.clearOperationResult()
+                }
+                null -> {}
+            }
         }
     }
 
@@ -75,16 +87,7 @@ class MyPostsFragment : Fragment() {
             .setMessage("Are you sure you want to delete \"${event.title}\"?")
             .setNegativeButton("Cancel", null)
             .setPositiveButton("Delete") { _, _ ->
-                val user = authManager.getCurrentUser() ?: return@setPositiveButton
-                when (val result = eventRepository.deleteEvent(user.id, event)) {
-                    is EventRepository.EventResult.Success -> {
-                        Toast.makeText(context, "Post deleted", Toast.LENGTH_SHORT).show()
-                        loadEvents()
-                    }
-                    is EventRepository.EventResult.Error -> {
-                        Toast.makeText(context, result.message, Toast.LENGTH_SHORT).show()
-                    }
-                }
+                viewModel.deleteEvent(event)
             }
             .show()
     }
@@ -128,7 +131,6 @@ class MyPostsFragment : Fragment() {
         descriptionEdit.setText(event.description ?: "")
         maxPlayersEdit.setText(event.maxPlayers.toString())
 
-        // Load existing image
         editImageUri = event.imageUri?.let { Uri.parse(it) }
         editImageUri?.let {
             try {
@@ -148,25 +150,17 @@ class MyPostsFragment : Fragment() {
             .setView(dialogView)
             .setNegativeButton("Cancel", null)
             .setPositiveButton("Save") { _, _ ->
-                val user = authManager.getCurrentUser() ?: return@setPositiveButton
                 val updatedEvent = event.copy(
                     title = titleEdit.text.toString().ifBlank { event.title },
                     description = descriptionEdit.text.toString(),
                     maxPlayers = maxPlayersEdit.text.toString().toIntOrNull() ?: event.maxPlayers,
                     imageUri = editImageUri?.toString() ?: event.imageUri
                 )
-                when (val result = eventRepository.updateEvent(user.id, updatedEvent)) {
-                    is EventRepository.EventResult.Success -> {
-                        Toast.makeText(context, "Post updated", Toast.LENGTH_SHORT).show()
-                        loadEvents()
-                    }
-                    is EventRepository.EventResult.Error -> {
-                        Toast.makeText(context, result.message, Toast.LENGTH_SHORT).show()
-                    }
-                }
+                viewModel.updateEvent(updatedEvent)
             }
             .show()
     }
+
     class MyEventsAdapter(
         private val items: MutableList<Event>,
         private val onEdit: (Event) -> Unit,

--- a/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/profile/ProfileFragment.kt
@@ -7,16 +7,23 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import com.example.playground.R
 import com.example.playground.SignInActivity
-import com.example.playground.auth.AuthManager
+import com.example.playground.repository.AuthRepository
+import com.example.playground.viewmodel.ProfileViewModel
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 
 class ProfileFragment : Fragment() {
 
-    private lateinit var authManager: AuthManager
-    private var isEditing = false
+    private lateinit var viewModel: ProfileViewModel
+
+    private lateinit var nameInput: TextInputEditText
+    private lateinit var emailInput: TextInputEditText
+    private lateinit var savedCourtsInput: TextInputEditText
+    private lateinit var editProfileButton: MaterialButton
+    private lateinit var logoutButton: MaterialButton
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -27,42 +34,57 @@ class ProfileFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        authManager = AuthManager(requireContext())
 
-        var user = authManager.getCurrentUser()
+        val authRepository = AuthRepository.getInstance(requireContext())
+        viewModel = ViewModelProvider(
+            this,
+            ProfileViewModel.Factory(authRepository)
+        )[ProfileViewModel::class.java]
 
-        val nameInput = view.findViewById<TextInputEditText>(R.id.nameInput)
-        val emailInput = view.findViewById<TextInputEditText>(R.id.emailInput)
-        val savedCourtsInput = view.findViewById<TextInputEditText>(R.id.savedCourtsInput)
-        val editProfileButton = view.findViewById<MaterialButton>(R.id.editProfileButton)
-        val logoutButton = view.findViewById<MaterialButton>(R.id.logoutButton)
+        nameInput = view.findViewById(R.id.nameInput)
+        emailInput = view.findViewById(R.id.emailInput)
+        savedCourtsInput = view.findViewById(R.id.savedCourtsInput)
+        editProfileButton = view.findViewById(R.id.editProfileButton)
+        logoutButton = view.findViewById(R.id.logoutButton)
 
-        nameInput.setText(user?.displayName?.ifEmpty { user?.email } ?: "Guest")
-        emailInput.setText(user?.email ?: "")
         savedCourtsInput.setText("0 saved courts")
         nameInput.isEnabled = false
 
+        observeViewModel()
+        setupActions()
+        viewModel.loadUser()
+    }
+
+    private fun observeViewModel() {
+        viewModel.user.observe(viewLifecycleOwner) { user ->
+            nameInput.setText(user?.displayName?.ifEmpty { user.email } ?: "Guest")
+            emailInput.setText(user?.email ?: "")
+        }
+
+        viewModel.isEditing.observe(viewLifecycleOwner) { editing ->
+            nameInput.isEnabled = editing
+            editProfileButton.text = if (editing) "Save Profile" else "Edit Profile"
+            if (editing) nameInput.requestFocus()
+        }
+
+        viewModel.profileSaved.observe(viewLifecycleOwner) { saved ->
+            if (saved) {
+                Toast.makeText(requireContext(), "Profile updated", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun setupActions() {
         editProfileButton.setOnClickListener {
-            if (isEditing) {
-                val newName = nameInput.text.toString().trim()
-                if (newName.isNotEmpty() && user != null) {
-                    user = user!!.copy(displayName = newName)
-                    authManager.updateUser(user!!)
-                    nameInput.isEnabled = false
-                    editProfileButton.text = "Edit Profile"
-                    isEditing = false
-                    Toast.makeText(requireContext(), "Profile updated", Toast.LENGTH_SHORT).show()
-                }
+            if (viewModel.isEditing.value == true) {
+                viewModel.saveProfile(nameInput.text.toString().trim())
             } else {
-                nameInput.isEnabled = true
-                nameInput.requestFocus()
-                editProfileButton.text = "Save Profile"
-                isEditing = true
+                viewModel.startEditing()
             }
         }
 
         logoutButton.setOnClickListener {
-            authManager.signOut()
+            viewModel.signOut()
             requireActivity().finish()
             startActivity(Intent(requireContext(), SignInActivity::class.java))
         }

--- a/app/src/main/java/com/example/playground/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/playground/viewmodel/MapViewModel.kt
@@ -1,0 +1,190 @@
+package com.example.playground.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.playground.data.Comment
+import com.example.playground.data.Event
+import com.example.playground.data.User
+import com.example.playground.repository.AuthRepository
+import com.example.playground.repository.EventRepository
+import kotlinx.coroutines.launch
+
+class MapViewModel(
+    private val authRepository: AuthRepository,
+    private val eventRepository: EventRepository
+) : ViewModel() {
+
+    private val _allEvents = MutableLiveData<List<Event>>(emptyList())
+
+    private val _filteredEvents = MutableLiveData<List<Event>>(emptyList())
+    val filteredEvents: LiveData<List<Event>> = _filteredEvents
+
+    private val _selectedEvent = MutableLiveData<Event?>(null)
+    val selectedEvent: LiveData<Event?> = _selectedEvent
+
+    private val _eventDetails = MutableLiveData<EventDetails?>(null)
+    val eventDetails: LiveData<EventDetails?> = _eventDetails
+
+    private val _comments = MutableLiveData<List<CommentWithAuthor>>(emptyList())
+    val comments: LiveData<List<CommentWithAuthor>> = _comments
+
+    var selectedSport: String = "All"
+        private set
+
+    var searchQuery: String = ""
+        private set
+
+    fun loadEvents() {
+        viewModelScope.launch {
+            _allEvents.value = eventRepository.getAllEvents()
+            applyFilters()
+        }
+    }
+
+    fun setSport(sport: String) {
+        selectedSport = sport
+        applyFilters()
+    }
+
+    fun setSearchQuery(query: String) {
+        searchQuery = query
+        applyFilters()
+    }
+
+    private fun applyFilters() {
+        val events = _allEvents.value.orEmpty()
+        val query = searchQuery.trim().lowercase()
+
+        _filteredEvents.value = events.filter { event ->
+            val hasCoordinates = event.latitude != 0.0 && event.longitude != 0.0
+            val sportMatches = selectedSport == "All" || event.sport.equals(selectedSport, ignoreCase = true)
+            val textMatches = query.isEmpty() ||
+                    event.title.lowercase().contains(query) ||
+                    event.sport.lowercase().contains(query) ||
+                    event.locationLabel.lowercase().contains(query)
+            hasCoordinates && sportMatches && textMatches
+        }
+    }
+
+    fun selectEvent(event: Event) {
+        _selectedEvent.value = event
+        refreshEventDetails(event)
+        viewModelScope.launch {
+            eventRepository.fetchJoinsForEvent(event.id)
+            eventRepository.fetchRatingsForEvent(event.id)
+            refreshComments(event.id)
+            if (_selectedEvent.value?.id == event.id) {
+                refreshEventDetails(event)
+            }
+        }
+    }
+
+    fun clearSelectedEvent() {
+        _selectedEvent.value = null
+        _eventDetails.value = null
+        _comments.value = emptyList()
+    }
+
+    fun joinOrUnjoinEvent() {
+        val event = _selectedEvent.value ?: return
+        val currentUser = authRepository.getCurrentUser() ?: return
+
+        if (eventRepository.isJoined(event.id, currentUser.id)) {
+            eventRepository.unjoinEvent(event.id, currentUser.id)
+        } else {
+            val joinCount = eventRepository.getJoinCount(event.id)
+            if (joinCount >= event.maxPlayers) {
+                refreshEventDetails(event)
+                return
+            }
+            eventRepository.joinEvent(event.id, currentUser.id)
+        }
+        refreshEventDetails(event)
+    }
+
+    fun rateEvent(stars: Int) {
+        val event = _selectedEvent.value ?: return
+        val currentUser = authRepository.getCurrentUser() ?: return
+        eventRepository.rateEvent(event.id, currentUser.id, stars.coerceIn(1, 5))
+        refreshEventDetails(event)
+    }
+
+    fun postComment(text: String) {
+        val event = _selectedEvent.value ?: return
+        val user = authRepository.getCurrentUser() ?: return
+        if (text.isBlank()) return
+
+        eventRepository.postComment(event.id, user.id, text)
+        viewModelScope.launch {
+            refreshComments(event.id)
+        }
+    }
+
+    fun getCurrentUser(): User? = authRepository.getCurrentUser()
+
+    private fun refreshEventDetails(event: Event) {
+        val currentUser = authRepository.getCurrentUser()
+        val participantCount = eventRepository.getJoinCount(event.id)
+        val isJoined = currentUser != null && eventRepository.isJoined(event.id, currentUser.id)
+        val userRating = currentUser?.let { eventRepository.getUserRating(event.id, it.id) }
+        val avgRating = eventRepository.getAverageRating(event.id)
+
+        _eventDetails.value = EventDetails(
+            event = event,
+            participantCount = participantCount,
+            isJoined = isJoined,
+            userRating = userRating,
+            averageRating = avgRating,
+            hostDisplayName = resolveHostName(event, currentUser)
+        )
+    }
+
+    private fun resolveHostName(event: Event, currentUser: User?): String {
+        return if (currentUser != null && currentUser.id == event.hostId) {
+            currentUser.displayName.ifEmpty { currentUser.email }
+        } else {
+            "Host #${event.hostId}"
+        }
+    }
+
+    private suspend fun refreshComments(eventId: Long) {
+        val rawComments = eventRepository.getCommentsForEvent(eventId)
+        val currentUser = authRepository.getCurrentUser()
+
+        _comments.value = rawComments.map { comment ->
+            val authorName = if (currentUser != null && currentUser.id == comment.authorId) {
+                currentUser.displayName.ifEmpty { currentUser.email }
+            } else {
+                "User ${comment.authorId}"
+            }
+            CommentWithAuthor(comment, authorName)
+        }
+    }
+
+    data class EventDetails(
+        val event: Event,
+        val participantCount: Int,
+        val isJoined: Boolean,
+        val userRating: Int?,
+        val averageRating: Float,
+        val hostDisplayName: String
+    )
+
+    data class CommentWithAuthor(
+        val comment: Comment,
+        val authorName: String
+    )
+
+    class Factory(
+        private val authRepository: AuthRepository,
+        private val eventRepository: EventRepository
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return MapViewModel(authRepository, eventRepository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/viewmodel/MyPostsViewModel.kt
+++ b/app/src/main/java/com/example/playground/viewmodel/MyPostsViewModel.kt
@@ -1,0 +1,81 @@
+package com.example.playground.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.playground.data.Event
+import com.example.playground.repository.AuthRepository
+import com.example.playground.repository.EventRepository
+import kotlinx.coroutines.launch
+
+class MyPostsViewModel(
+    private val authRepository: AuthRepository,
+    private val eventRepository: EventRepository
+) : ViewModel() {
+
+    private val _myEvents = MutableLiveData<List<Event>>(emptyList())
+    val myEvents: LiveData<List<Event>> = _myEvents
+
+    private val _isEmpty = MutableLiveData(true)
+    val isEmpty: LiveData<Boolean> = _isEmpty
+
+    private val _operationResult = MutableLiveData<OperationResult?>()
+    val operationResult: LiveData<OperationResult?> = _operationResult
+
+    fun loadEvents() {
+        val user = authRepository.getCurrentUser() ?: return
+        viewModelScope.launch {
+            val all = eventRepository.getAllEvents()
+            val mine = all.filter { it.hostId == user.id }
+            _myEvents.value = mine
+            _isEmpty.value = mine.isEmpty()
+        }
+    }
+
+    fun deleteEvent(event: Event) {
+        val user = authRepository.getCurrentUser() ?: return
+        when (val result = eventRepository.deleteEvent(user.id, event)) {
+            is EventRepository.EventResult.Success -> {
+                _operationResult.value = OperationResult.Success("Post deleted")
+                loadEvents()
+            }
+            is EventRepository.EventResult.Error -> {
+                _operationResult.value = OperationResult.Error(result.message)
+            }
+        }
+    }
+
+    fun updateEvent(event: Event) {
+        val user = authRepository.getCurrentUser() ?: return
+        when (val result = eventRepository.updateEvent(user.id, event)) {
+            is EventRepository.EventResult.Success -> {
+                _operationResult.value = OperationResult.Success("Post updated")
+                loadEvents()
+            }
+            is EventRepository.EventResult.Error -> {
+                _operationResult.value = OperationResult.Error(result.message)
+            }
+        }
+    }
+
+    fun clearOperationResult() {
+        _operationResult.value = null
+    }
+
+    sealed class OperationResult {
+        data class Success(val message: String) : OperationResult()
+        data class Error(val message: String) : OperationResult()
+    }
+
+    class Factory(
+        private val authRepository: AuthRepository,
+        private val eventRepository: EventRepository
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return MyPostsViewModel(authRepository, eventRepository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/playground/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/playground/viewmodel/ProfileViewModel.kt
@@ -1,0 +1,54 @@
+package com.example.playground.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.playground.data.User
+import com.example.playground.repository.AuthRepository
+
+class ProfileViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _user = MutableLiveData<User?>()
+    val user: LiveData<User?> = _user
+
+    private val _isEditing = MutableLiveData(false)
+    val isEditing: LiveData<Boolean> = _isEditing
+
+    private val _profileSaved = MutableLiveData<Boolean>()
+    val profileSaved: LiveData<Boolean> = _profileSaved
+
+    fun loadUser() {
+        _user.value = authRepository.getCurrentUser()
+    }
+
+    fun startEditing() {
+        _isEditing.value = true
+    }
+
+    fun saveProfile(newName: String) {
+        val current = _user.value ?: return
+        if (newName.isBlank()) return
+
+        val updated = current.copy(displayName = newName)
+        authRepository.updateUser(updated)
+        _user.value = updated
+        _isEditing.value = false
+        _profileSaved.value = true
+    }
+
+    fun signOut() {
+        authRepository.signOut()
+    }
+
+    class Factory(
+        private val authRepository: AuthRepository
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ProfileViewModel(authRepository) as T
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,8 +9,11 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/bottom_navigation" />
 

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/nav_map"
+        android:id="@+id/mapFragment"
         android:icon="@android:drawable/ic_dialog_map"
         android:title="Map" />
     <item
-        android:id="@+id/nav_create"
+        android:id="@+id/createEventFragment"
         android:icon="@android:drawable/ic_input_add"
         android:title="Create" />
     <item
-        android:id="@+id/nav_my_posts"
+        android:id="@+id/myPostsFragment"
         android:icon="@android:drawable/ic_menu_edit"
         android:title="My Posts" />
     <item
-        android:id="@+id/nav_profile"
+        android:id="@+id/profileFragment"
         android:icon="@android:drawable/ic_menu_myplaces"
         android:title="Profile" />
 </menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/mapFragment">
+
+    <fragment
+        android:id="@+id/mapFragment"
+        android:name="com.example.playground.ui.map.MapFragment"
+        android:label="Map"
+        tools:layout="@layout/fragment_map" />
+
+    <fragment
+        android:id="@+id/createEventFragment"
+        android:name="com.example.playground.ui.home.CreateEventFragment"
+        android:label="Create"
+        tools:layout="@layout/fragment_create_event" />
+
+    <fragment
+        android:id="@+id/myPostsFragment"
+        android:name="com.example.playground.ui.myposts.MyPostsFragment"
+        android:label="My Posts"
+        tools:layout="@layout/fragment_my_posts" />
+
+    <fragment
+        android:id="@+id/profileFragment"
+        android:name="com.example.playground.ui.profile.ProfileFragment"
+        android:label="Profile"
+        tools:layout="@layout/fragment_profile" />
+
+</navigation>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.androidx.navigation.safeargs.kotlin) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ constraintlayout = "2.2.1"
 room = "2.8.4"
 lifecycle = "2.8.7"
 ksp = "2.0.21-1.0.28"
+navigation = "2.8.9"
 googleServices = "4.4.2"
 firebaseBom = "33.7.0"
 
@@ -36,6 +37,9 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
 
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
+androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
+
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version = "1.8.1" }
 
 [plugins]
@@ -43,3 +47,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+androidx-navigation-safeargs-kotlin = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }


### PR DESCRIPTION
## Summary

- **Added `MapViewModel`**, `ProfileViewModel`, and `MyPostsViewModel` with LiveData to enforce the MVVM pattern across all fragments that were previously accessing repositories/AuthManager directly.
- **Refactored `MapFragment`**, `ProfileFragment`, and `MyPostsFragment` to observe ViewModel LiveData instead of calling data layer APIs directly.
- **Extended `AuthRepository`** with `updateUser()` and `signOut()` so ViewModels interact exclusively through the repository layer.
- **Added `lifecycle-livedata-ktx`** dependency.