### PR TITLE
Fix event editing creating duplicates and add loading indicators

### DIFF
--- a/app/src/main/java/com/example/playground/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/playground/repository/EventRepository.kt
@@ -57,8 +57,10 @@ class EventRepository(context: Context) {
                 Event.fromFirestoreMap(data, localHost.id)
             }
 
-            eventDao.deleteAll()
-            events.forEach { eventDao.insertEvent(it) }
+            if (events.isNotEmpty()) {
+                eventDao.deleteAll()
+                events.forEach { eventDao.insertEvent(it) }
+            }
 
             eventDao.getAllEvents()
         } catch (e: Exception) {
@@ -68,6 +70,15 @@ class EventRepository(context: Context) {
 
     fun getEventById(id: Long): Event? = eventDao.findById(id)
 
+    suspend fun getEventsByHost(hostId: Long): List<Event> {
+        getAllEvents()
+        return eventDao.getEventsByHost(hostId)
+    }
+
+    fun getLocalEventsByHost(hostId: Long): List<Event> {
+        return eventDao.getEventsByHost(hostId)
+    }
+
     fun updateEvent(hostId: Long, event: Event): EventResult {
         if (event.hostId != hostId) return EventResult.Error("Unauthorized")
 
@@ -76,14 +87,14 @@ class EventRepository(context: Context) {
         if (event.maxPlayers < 1) return EventResult.Error("Max players must be at least 1")
 
         eventDao.updateEvent(event)
-        syncEventToFirestore(event)
+        syncEventUpdate(event)
         return EventResult.Success(event.id)
     }
 
     fun deleteEvent(hostId: Long, event: Event): EventResult {
         if (event.hostId != hostId) return EventResult.Error("Unauthorized")
         eventDao.deleteEvent(event)
-        eventsCollection.document(event.id.toString()).delete()
+        deleteEventFromFirestore(event)
         return EventResult.Success(event.id)
     }
 
@@ -162,6 +173,43 @@ class EventRepository(context: Context) {
             }
     }
 
+    private fun syncEventUpdate(event: Event) {
+        val host = userDao.findById(event.hostId)
+        val hostUid = host?.firebaseUid ?: ""
+        val data = event.toFirestoreMap(hostUid)
+
+        eventsCollection
+            .whereEqualTo("hostFirebaseUid", hostUid)
+            .whereEqualTo("startTime", event.startTime)
+            .get()
+            .addOnSuccessListener { snapshot ->
+                if (snapshot.documents.isNotEmpty()) {
+                    snapshot.documents.forEach { it.reference.set(data) }
+                } else {
+                    eventsCollection.document(event.id.toString()).set(data)
+                }
+            }
+            .addOnFailureListener { e ->
+                android.util.Log.e("EventRepository", "Failed to sync event update to Firestore", e)
+            }
+    }
+
+    private fun deleteEventFromFirestore(event: Event) {
+        val host = userDao.findById(event.hostId)
+        val hostUid = host?.firebaseUid ?: ""
+
+        eventsCollection
+            .whereEqualTo("hostFirebaseUid", hostUid)
+            .whereEqualTo("startTime", event.startTime)
+            .get()
+            .addOnSuccessListener { snapshot ->
+                snapshot.documents.forEach { it.reference.delete() }
+            }
+            .addOnFailureListener { e ->
+                android.util.Log.e("EventRepository", "Failed to delete event from Firestore", e)
+            }
+    }
+
     private fun syncCommentToFirestore(comment: Comment) {
         val author = userDao.findById(comment.authorId)
         val authorUid = author?.firebaseUid ?: ""
@@ -175,7 +223,7 @@ class EventRepository(context: Context) {
     fun joinEvent(eventId: Long, userId: Long) {
         val join = EventJoin(eventId = eventId, userId = userId)
         eventJoinDao.insert(join)
-        syncJoinToFirestore(join)
+        syncJoinToFirestore(eventId, userId)
     }
 
     fun unjoinEvent(eventId: Long, userId: Long) {
@@ -183,8 +231,13 @@ class EventRepository(context: Context) {
         val user = userDao.findById(userId)
         val event = eventDao.findById(eventId)
         val host = event?.let { userDao.findById(it.hostId) }
-        val firestoreKey = "${user?.firebaseUid}_${event?.id}"
-        joinsCollection.document(firestoreKey).delete()
+        val hostUid = host?.firebaseUid ?: ""
+        val userUid = user?.firebaseUid ?: ""
+
+        if (event != null) {
+            val firestoreKey = "${userUid}_${hostUid}_${event.startTime}"
+            joinsCollection.document(firestoreKey).delete()
+        }
     }
 
     fun isJoined(eventId: Long, userId: Long): Boolean =
@@ -194,9 +247,14 @@ class EventRepository(context: Context) {
         eventJoinDao.getJoinCount(eventId)
 
     suspend fun fetchJoinsForEvent(eventId: Long) {
+        val event = eventDao.findById(eventId) ?: return
+        val host = userDao.findById(event.hostId)
+        val hostUid = host?.firebaseUid ?: return
+
         try {
             val snapshot = joinsCollection
-                .whereEqualTo("eventFirestoreId", eventId.toString())
+                .whereEqualTo("hostFirebaseUid", hostUid)
+                .whereEqualTo("startTime", event.startTime)
                 .get()
                 .await()
 
@@ -214,7 +272,7 @@ class EventRepository(context: Context) {
     fun rateEvent(eventId: Long, userId: Long, stars: Int) {
         val rating = EventRating(eventId = eventId, userId = userId, stars = stars)
         eventRatingDao.insert(rating)
-        syncRatingToFirestore(rating)
+        syncRatingToFirestore(eventId, userId, stars)
     }
 
     fun getUserRating(eventId: Long, userId: Long): Int? =
@@ -224,9 +282,14 @@ class EventRepository(context: Context) {
         eventRatingDao.getAverageRating(eventId) ?: 0f
 
     suspend fun fetchRatingsForEvent(eventId: Long) {
+        val event = eventDao.findById(eventId) ?: return
+        val host = userDao.findById(event.hostId)
+        val hostUid = host?.firebaseUid ?: return
+
         try {
             val snapshot = ratingsCollection
-                .whereEqualTo("eventFirestoreId", eventId.toString())
+                .whereEqualTo("hostFirebaseUid", hostUid)
+                .whereEqualTo("startTime", event.startTime)
                 .get()
                 .await()
 
@@ -242,22 +305,39 @@ class EventRepository(context: Context) {
         }
     }
 
-    private fun syncJoinToFirestore(join: EventJoin) {
-        val user = userDao.findById(join.userId)
-        val event = eventDao.findById(join.eventId)
+    private fun syncJoinToFirestore(eventId: Long, userId: Long) {
+        val user = userDao.findById(userId)
+        val event = eventDao.findById(eventId)
         val host = event?.let { userDao.findById(it.hostId) }
         val userUid = user?.firebaseUid ?: ""
-        val firestoreKey = "${userUid}_${join.eventId}"
-        joinsCollection.document(firestoreKey)
-            .set(join.toFirestoreMap(join.eventId.toString(), userUid))
+        val hostUid = host?.firebaseUid ?: ""
+        val startTime = event?.startTime ?: 0L
+
+        val firestoreKey = "${userUid}_${hostUid}_${startTime}"
+        val data = mapOf(
+            "userFirebaseUid" to userUid,
+            "hostFirebaseUid" to hostUid,
+            "startTime" to startTime
+        )
+        joinsCollection.document(firestoreKey).set(data)
     }
 
-    private fun syncRatingToFirestore(rating: EventRating) {
-        val user = userDao.findById(rating.userId)
+    private fun syncRatingToFirestore(eventId: Long, userId: Long, stars: Int) {
+        val user = userDao.findById(userId)
+        val event = eventDao.findById(eventId)
+        val host = event?.let { userDao.findById(it.hostId) }
         val userUid = user?.firebaseUid ?: ""
-        val firestoreKey = "${userUid}_${rating.eventId}"
-        ratingsCollection.document(firestoreKey)
-            .set(rating.toFirestoreMap(rating.eventId.toString(), userUid))
+        val hostUid = host?.firebaseUid ?: ""
+        val startTime = event?.startTime ?: 0L
+
+        val firestoreKey = "${userUid}_${hostUid}_${startTime}"
+        val data = mapOf(
+            "userFirebaseUid" to userUid,
+            "hostFirebaseUid" to hostUid,
+            "startTime" to startTime,
+            "stars" to stars
+        )
+        ratingsCollection.document(firestoreKey).set(data)
     }
 
     companion object {

--- a/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/map/MapFragment.kt
@@ -33,6 +33,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.chip.Chip
+import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 
 class MapFragment : Fragment(), OnMapReadyCallback {
@@ -83,6 +84,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     private lateinit var imComingButton: MaterialButton
 
     private lateinit var eventImageView: android.widget.ImageView
+    private lateinit var progressIndicator: LinearProgressIndicator
 
     private var activeExpanded = true
 
@@ -158,6 +160,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         addCommentButton = view.findViewById(R.id.addCommentButton)
         imComingButton = view.findViewById(R.id.imComingButton)
         eventImageView = view.findViewById(R.id.eventImageView)
+        progressIndicator = view.findViewById(R.id.progressIndicator)
     }
 
     private fun setupActions() {
@@ -212,6 +215,10 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun observeViewModel() {
+        viewModel.isLoading.observe(viewLifecycleOwner) { loading ->
+            progressIndicator.visibility = if (loading) View.VISIBLE else View.GONE
+        }
+
         viewModel.filteredEvents.observe(viewLifecycleOwner) { events ->
             showMarkers(events)
             activeGamesCountText.text = "${events.size} games near you"

--- a/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
@@ -17,6 +17,7 @@ import com.example.playground.repository.EventRepository
 import com.example.playground.viewmodel.MyPostsViewModel
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 import android.app.AlertDialog
 import android.net.Uri
@@ -28,6 +29,7 @@ class MyPostsFragment : Fragment() {
     private lateinit var viewModel: MyPostsViewModel
     private lateinit var recyclerView: RecyclerView
     private lateinit var emptyText: TextView
+    private lateinit var progressIndicator: CircularProgressIndicator
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -46,6 +48,7 @@ class MyPostsFragment : Fragment() {
 
         recyclerView = view.findViewById(R.id.recyclerView)
         emptyText = view.findViewById(R.id.emptyText)
+        progressIndicator = view.findViewById(R.id.progressIndicator)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
 
         observeViewModel()
@@ -53,6 +56,18 @@ class MyPostsFragment : Fragment() {
     }
 
     private fun observeViewModel() {
+        viewModel.isLoading.observe(viewLifecycleOwner) { loading ->
+            progressIndicator.visibility = if (loading) View.VISIBLE else View.GONE
+            if (loading) {
+                recyclerView.visibility = View.GONE
+                emptyText.visibility = View.GONE
+            } else {
+                val empty = viewModel.isEmpty.value ?: true
+                recyclerView.visibility = if (empty) View.GONE else View.VISIBLE
+                emptyText.visibility = if (empty) View.VISIBLE else View.GONE
+            }
+        }
+
         viewModel.myEvents.observe(viewLifecycleOwner) { events ->
             recyclerView.adapter = MyEventsAdapter(
                 items = events.toMutableList(),
@@ -62,6 +77,7 @@ class MyPostsFragment : Fragment() {
         }
 
         viewModel.isEmpty.observe(viewLifecycleOwner) { empty ->
+            if (viewModel.isLoading.value == true) return@observe
             recyclerView.visibility = if (empty) View.GONE else View.VISIBLE
             emptyText.visibility = if (empty) View.VISIBLE else View.GONE
         }

--- a/app/src/main/java/com/example/playground/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/playground/viewmodel/MapViewModel.kt
@@ -22,6 +22,9 @@ class MapViewModel(
     private val _filteredEvents = MutableLiveData<List<Event>>(emptyList())
     val filteredEvents: LiveData<List<Event>> = _filteredEvents
 
+    private val _isLoading = MutableLiveData(false)
+    val isLoading: LiveData<Boolean> = _isLoading
+
     private val _selectedEvent = MutableLiveData<Event?>(null)
     val selectedEvent: LiveData<Event?> = _selectedEvent
 
@@ -38,9 +41,11 @@ class MapViewModel(
         private set
 
     fun loadEvents() {
+        _isLoading.value = true
         viewModelScope.launch {
             _allEvents.value = eventRepository.getAllEvents()
             applyFilters()
+            _isLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/example/playground/viewmodel/MyPostsViewModel.kt
+++ b/app/src/main/java/com/example/playground/viewmodel/MyPostsViewModel.kt
@@ -21,16 +21,20 @@ class MyPostsViewModel(
     private val _isEmpty = MutableLiveData(true)
     val isEmpty: LiveData<Boolean> = _isEmpty
 
+    private val _isLoading = MutableLiveData(false)
+    val isLoading: LiveData<Boolean> = _isLoading
+
     private val _operationResult = MutableLiveData<OperationResult?>()
     val operationResult: LiveData<OperationResult?> = _operationResult
 
     fun loadEvents() {
         val user = authRepository.getCurrentUser() ?: return
+        _isLoading.value = true
         viewModelScope.launch {
-            val all = eventRepository.getAllEvents()
-            val mine = all.filter { it.hostId == user.id }
-            _myEvents.value = mine
-            _isEmpty.value = mine.isEmpty()
+            val all = eventRepository.getEventsByHost(user.id)
+            _myEvents.value = all
+            _isEmpty.value = all.isEmpty()
+            _isLoading.value = false
         }
     }
 
@@ -39,7 +43,7 @@ class MyPostsViewModel(
         when (val result = eventRepository.deleteEvent(user.id, event)) {
             is EventRepository.EventResult.Success -> {
                 _operationResult.value = OperationResult.Success("Post deleted")
-                loadEvents()
+                loadLocalEvents()
             }
             is EventRepository.EventResult.Error -> {
                 _operationResult.value = OperationResult.Error(result.message)
@@ -52,12 +56,19 @@ class MyPostsViewModel(
         when (val result = eventRepository.updateEvent(user.id, event)) {
             is EventRepository.EventResult.Success -> {
                 _operationResult.value = OperationResult.Success("Post updated")
-                loadEvents()
+                loadLocalEvents()
             }
             is EventRepository.EventResult.Error -> {
                 _operationResult.value = OperationResult.Error(result.message)
             }
         }
+    }
+
+    private fun loadLocalEvents() {
+        val user = authRepository.getCurrentUser() ?: return
+        val mine = eventRepository.getLocalEventsByHost(user.id)
+        _myEvents.value = mine
+        _isEmpty.value = mine.isEmpty()
     }
 
     fun clearOperationResult() {

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -100,6 +100,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/filterScrollView" />
 
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progressIndicator"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@id/map"
+        app:layout_constraintStart_toStartOf="@id/map"
+        app:layout_constraintTop_toTopOf="@id/map" />
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/activeGamesCard"
         android:layout_width="260dp"

--- a/app/src/main/res/layout/fragment_my_posts.xml
+++ b/app/src/main/res/layout/fragment_my_posts.xml
@@ -19,6 +19,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/progressIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/myPostsTitle" />
+
     <TextView
         android:id="@+id/emptyText"
         android:layout_width="0dp"


### PR DESCRIPTION
## Summary

- **Fix edit creating duplicates**: Event updates and deletes now query Firestore by stable fields (`hostFirebaseUid` + `startTime`) instead of using volatile local auto-generated IDs as document keys.
- **Fix joins/ratings not persisting**: Joins and ratings are now stored and fetched in Firestore using stable keys, so they survive local DB re-syncs.
- **Add loading indicators**: Circular progress on My Posts, linear progress on the Map screen while data is being fetched.
- **Fix My Posts visibility bug**: RecyclerView now correctly becomes visible after loading completes.
- **Immediate UI refresh after edit/delete**: Reloads from local DB instead of re-fetching from Firestore (avoids race with async sync).
