### PR TITLE
Fix event image upload on edit to use Firebase Storage

### DIFF
--- a/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
+++ b/app/src/main/java/com/example/playground/ui/myposts/MyPostsFragment.kt
@@ -166,13 +166,46 @@ class MyPostsFragment : Fragment() {
             .setView(dialogView)
             .setNegativeButton("Cancel", null)
             .setPositiveButton("Save") { _, _ ->
-                val updatedEvent = event.copy(
-                    title = titleEdit.text.toString().ifBlank { event.title },
-                    description = descriptionEdit.text.toString(),
-                    maxPlayers = maxPlayersEdit.text.toString().toIntOrNull() ?: event.maxPlayers,
-                    imageUri = editImageUri?.toString() ?: event.imageUri
-                )
-                viewModel.updateEvent(updatedEvent)
+                val newTitle = titleEdit.text.toString().ifBlank { event.title }
+                val newDescription = descriptionEdit.text.toString()
+                val newMaxPlayers = maxPlayersEdit.text.toString().toIntOrNull() ?: event.maxPlayers
+                val newLocalUri = editImageUri
+
+                val isNewImage = newLocalUri != null
+                        && newLocalUri.toString() != event.imageUri
+                        && newLocalUri.scheme == "file"
+
+                if (isNewImage) {
+                    val ref = com.google.firebase.storage.FirebaseStorage.getInstance()
+                        .reference
+                        .child("event_images/event_${System.currentTimeMillis()}.jpg")
+
+                    ref.putFile(newLocalUri!!)
+                        .continueWithTask { task ->
+                            if (!task.isSuccessful) throw task.exception ?: Exception("Upload failed")
+                            ref.downloadUrl
+                        }
+                        .addOnSuccessListener { downloadUri ->
+                            val updatedEvent = event.copy(
+                                title = newTitle,
+                                description = newDescription,
+                                maxPlayers = newMaxPlayers,
+                                imageUri = downloadUri.toString()
+                            )
+                            viewModel.updateEvent(updatedEvent)
+                        }
+                        .addOnFailureListener {
+                            Toast.makeText(context, "Image upload failed", Toast.LENGTH_SHORT).show()
+                        }
+                } else {
+                    val updatedEvent = event.copy(
+                        title = newTitle,
+                        description = newDescription,
+                        maxPlayers = newMaxPlayers,
+                        imageUri = editImageUri?.toString() ?: event.imageUri
+                    )
+                    viewModel.updateEvent(updatedEvent)
+                }
             }
             .show()
     }


### PR DESCRIPTION
## Summary
- Fixed a bug where editing an event image in MyPostsFragment saved the local `file://` URI to Firestore instead of uploading to Firebase Storage
- Other users would see broken images for edited events because the local path is inaccessible from other devices
- New images are now uploaded to Firebase Storage (`event_images/`) and the download URL is stored in Firestore, matching the behavior of event creation

## Test plan
- [ ] Create an event with an image, verify the image appears for other users
- [ ] Edit an existing event and change its image, verify the new image appears for other users
- [ ] Edit an event without changing the image, verify the original image is preserved